### PR TITLE
feat(F2-04): Implementa vinculação de documentos à licitação

### DIFF
--- a/apps/api/prisma/migrations/20260117024536_add_soft_delete_deleted_at/migration.sql
+++ b/apps/api/prisma/migrations/20260117024536_add_soft_delete_deleted_at/migration.sql
@@ -1,3 +1,0 @@
--- This migration was already applied to the database
--- It's kept here only to resolve migration history drift
--- The actual migration content is in 20260118185740_add_soft_delete

--- a/apps/api/prisma/migrations/20260120182113_add_bid_id_to_documents/migration.sql
+++ b/apps/api/prisma/migrations/20260120182113_add_bid_id_to_documents/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "documents" ADD COLUMN     "bidId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "documents_empresaId_bidId_idx" ON "documents"("empresaId", "bidId");
+
+-- CreateIndex
+CREATE INDEX "documents_bidId_idx" ON "documents"("bidId");
+
+-- AddForeignKey
+ALTER TABLE "documents" ADD CONSTRAINT "documents_bidId_fkey" FOREIGN KEY ("bidId") REFERENCES "bids"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -83,6 +83,8 @@ model Bid {
 
   // Relacionamento: Uma licitação pertence a uma empresa
   empresa Empresa @relation(fields: [empresaId], references: [id], onDelete: Cascade)
+  // Relacionamento: Uma licitação pode ter vários documentos
+  documents Document[]
 
   @@index([empresaId])
   @@index([createdAt])
@@ -137,10 +139,15 @@ model Document {
   issuedAt   DateTime? // Data de emissão do documento (opcional)
   expiresAt  DateTime? // Data de vencimento do documento (opcional, obrigatório se doesExpire=true)
 
+  // Associação opcional com licitação
+  bidId String? // Opcional: associação com licitação específica
+
   // Relacionamento: Um documento pertence a uma empresa
-  empresa  Empresa           @relation(fields: [empresaId], references: [id], onDelete: Cascade)
+  empresa Empresa @relation(fields: [empresaId], references: [id], onDelete: Cascade)
   // Relacionamento: Um documento foi enviado por um usuário
-  uploader User              @relation(fields: [uploadedBy], references: [id], onDelete: Cascade)
+  uploader User @relation(fields: [uploadedBy], references: [id], onDelete: Cascade)
+  // Relacionamento: Um documento pode estar associado a uma licitação (opcional)
+  bid Bid? @relation(fields: [bidId], references: [id], onDelete: SetNull)
   // Relacionamento: Um documento pode ter várias versões
   versions DocumentVersion[]
 
@@ -148,7 +155,9 @@ model Document {
   @@index([empresaId, category]) // Consultas por empresa e categoria
   @@index([empresaId, deletedAt]) // Índice composto para queries de tenant + soft delete
   @@index([empresaId, expiresAt]) // Índice composto para consultas de vencimento e dashboard
+  @@index([empresaId, bidId]) // Consultas por empresa e licitação
   @@index([uploadedBy])
+  @@index([bidId]) // Consultas por licitação
   @@index([createdAt])
   @@index([deletedAt]) // Otimizar queries que filtram deletados
   @@map("documents")

--- a/apps/api/src/bid/bid.controller.ts
+++ b/apps/api/src/bid/bid.controller.ts
@@ -15,6 +15,7 @@ import {
   Req,
 } from "@nestjs/common";
 import { BidService } from "./bid.service";
+import { DocumentService } from "../document/document.service";
 import { SoftDeleteService } from "../common/services/soft-delete.service";
 import { AuditLogService } from "../audit-log/audit-log.service";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
@@ -44,6 +45,7 @@ import type { Request } from "express";
 export class BidController {
   constructor(
     private readonly bidService: BidService,
+    private readonly documentService: DocumentService,
     private readonly softDeleteService: SoftDeleteService,
     private readonly auditLogService: AuditLogService,
   ) {}
@@ -109,6 +111,44 @@ export class BidController {
       modality,
       legalStatus,
       operationalState,
+      search,
+    });
+  }
+
+  /**
+   * Lista documentos vinculados a uma licitação
+   * GET /bids/:id/documents
+   * 
+   * Retorna todos os documentos associados à licitação.
+   * 
+   * Query params:
+   * - page: número da página (default: 1)
+   * - limit: itens por página (default: 20, max: 100)
+   * - category: filtrar por categoria
+   * - search: buscar por nome
+   * 
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Get(":id/documents")
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async getDocuments(
+    @Param("id") id: string,
+    @Tenant() empresaId: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+    @Query("category") category?: string,
+    @Query("search") search?: string,
+  ) {
+    // Validar que a licitação existe e pertence ao tenant
+    await this.bidService.findOne(id, empresaId);
+
+    // Buscar documentos da licitação
+    return this.documentService.findAll({
+      empresaId,
+      bidId: id,
+      page: page ? parseInt(page, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      category,
       search,
     });
   }

--- a/apps/api/src/bid/bid.module.ts
+++ b/apps/api/src/bid/bid.module.ts
@@ -4,9 +4,10 @@ import { BidService } from "./bid.service";
 import { PrismaModule } from "../prisma/prisma.module";
 import { CommonModule } from "../common/common.module";
 import { AuditLogModule } from "../audit-log/audit-log.module";
+import { DocumentModule } from "../document/document.module";
 
 @Module({
-  imports: [PrismaModule, CommonModule, AuditLogModule],
+  imports: [PrismaModule, CommonModule, AuditLogModule, DocumentModule],
   controllers: [BidController],
   providers: [BidService],
   exports: [BidService],

--- a/apps/api/src/document/document.controller.ts
+++ b/apps/api/src/document/document.controller.ts
@@ -122,6 +122,7 @@ export class DocumentController {
       name?: string;
       category?: string;
       documentId?: string;
+      bidId?: string; // Opcional: vincular a uma licitação
       doesExpire?: string | boolean; // string (form-data) ou boolean
       issuedAt?: string;
       expiresAt?: string;
@@ -186,6 +187,7 @@ export class DocumentController {
     const result = createDocumentSchema.safeParse({
       name: body.name,
       category: body.category,
+      bidId: body.bidId || undefined, // Incluir bidId se fornecido
       ...validityData,
     });
 
@@ -224,6 +226,7 @@ export class DocumentController {
    * Query params:
    * - page: número da página (default: 1)
    * - limit: itens por página (default: 20, max: 100)
+   * - bidId: filtrar por licitação específica
    * - category: filtrar por categoria
    * - search: buscar por nome
    * - status: filtrar por status de validade (VALID, EXPIRING_SOON, EXPIRED, NO_EXPIRATION)
@@ -238,6 +241,7 @@ export class DocumentController {
   async findAll(
     @Query("page") page?: string,
     @Query("limit") limit?: string,
+    @Query("bidId") bidId?: string,
     @Query("category") category?: string,
     @Query("search") search?: string,
     @Query("status") status?: "VALID" | "EXPIRING_SOON" | "EXPIRED" | "NO_EXPIRATION",
@@ -252,6 +256,7 @@ export class DocumentController {
 
     return this.documentService.findAll({
       empresaId,
+      bidId,
       category,
       search,
       status,
@@ -525,5 +530,88 @@ export class DocumentController {
       throw new BadRequestException("Número de versão inválido");
     }
     return this.documentService.restoreVersion(id, versionNum, empresaId, user.id);
+  }
+
+  /**
+   * Vincula um documento a uma licitação
+   * POST /documents/:id/attach
+   *
+   * Body:
+   * - bidId: ID da licitação para vincular
+   *
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Post(":id/attach")
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  @Audit({ action: "document.attach", captureResourceId: true, resourceType: "Document" })
+  async attach(
+    @Param("id") id: string,
+    @Body() body: { bidId: string },
+    @Tenant() empresaId: string,
+    @CurrentUser() user: User,
+    @Req() request: Request,
+  ): Promise<Document> {
+    if (!body.bidId) {
+      throw new BadRequestException("bidId é obrigatório");
+    }
+
+    const document = await this.documentService.attachToBid(id, body.bidId, empresaId);
+
+    // Registrar auditoria específica
+    await this.auditLogService.record({
+      empresaId,
+      userId: user.id,
+      action: "document.attach",
+      resourceType: "Document",
+      resourceId: document.id,
+      metadata: {
+        bidId: body.bidId,
+        documentId: document.id,
+        documentName: document.name,
+      },
+      ip: (request as any).ip || (request as any).connection?.remoteAddress || null,
+      userAgent: (request as any).headers?.["user-agent"] || null,
+    });
+
+    return document;
+  }
+
+  /**
+   * Desvincula um documento de uma licitação
+   * POST /documents/:id/detach
+   *
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Post(":id/detach")
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  @Audit({ action: "document.detach", captureResourceId: true, resourceType: "Document" })
+  async detach(
+    @Param("id") id: string,
+    @Tenant() empresaId: string,
+    @CurrentUser() user: User,
+    @Req() request: Request,
+  ): Promise<Document> {
+    // Buscar documento antes de desvincular para registrar bidId anterior no audit
+    const documentBefore = await this.documentService.findOne(id, empresaId);
+
+    const document = await this.documentService.detachFromBid(id, empresaId);
+
+    // Registrar auditoria específica
+    await this.auditLogService.record({
+      empresaId,
+      userId: user.id,
+      action: "document.detach",
+      resourceType: "Document",
+      resourceId: document.id,
+      metadata: {
+        previousBidId: documentBefore.bidId || null,
+        documentId: document.id,
+        documentName: document.name,
+      },
+      ip: (request as any).ip || (request as any).connection?.remoteAddress || null,
+      userAgent: (request as any).headers?.["user-agent"] || null,
+    });
+
+    return document;
   }
 }

--- a/apps/api/src/document/document.service.ts
+++ b/apps/api/src/document/document.service.ts
@@ -29,6 +29,7 @@ import {
  */
 export interface ListDocumentsFilters {
   empresaId: string;
+  bidId?: string; // Opcional: filtrar por licitação específica
   category?: string;
   search?: string; // Busca por nome
   page?: number;
@@ -213,6 +214,10 @@ export class DocumentService {
     }
 
     // Caso contrário, criar novo documento com versão 1
+    const inputDataWithBid = data as CreateDocumentInput & {
+      bidId?: string | null;
+    };
+
     const document = await prismaWithTenant.document.create({
       data: {
         name: data.name,
@@ -223,6 +228,7 @@ export class DocumentService {
         url: fileUrl,
         uploadedBy: userId,
         empresaId,
+        bidId: inputDataWithBid.bidId || null, // Associar com licitação se fornecido
         doesExpire: validityData.doesExpire,
         issuedAt: validityData.issuedAt,
         expiresAt: validityData.expiresAt,
@@ -345,6 +351,11 @@ export class DocumentService {
       empresaId: filters.empresaId,
       deletedAt: null, // Sempre filtrar soft delete
     };
+
+    // Filtrar por licitação específica se fornecido
+    if (filters.bidId) {
+      where.bidId = filters.bidId;
+    }
 
     if (filters.category) {
       where.category = filters.category;
@@ -498,13 +509,16 @@ export class DocumentService {
     const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
 
     // Verificar se o documento existe e carregar estado atual
-    const existingDocument = await prismaWithTenant.document.findUnique({
+    const existingDocumentRaw = await prismaWithTenant.document.findUnique({
       where: { id },
     });
 
-    if (!existingDocument) {
+    if (!existingDocumentRaw) {
       throw new NotFoundException(`Documento com ID ${id} não encontrado`);
     }
+
+    // Mapear para Document para ter acesso a todos os campos tipados
+    const existingDocument = this.mapToDocument(existingDocumentRaw);
 
     // Preparar dados de atualização
     const updateData: any = {};
@@ -517,16 +531,21 @@ export class DocumentService {
       updateData.category = data.category;
     }
 
+    // Atualizar bidId se fornecido
+    if (data.bidId !== undefined) {
+      updateData.bidId = data.bidId;
+    }
+
     // Fazer merge do patch com estado atual para campos de validade
     // REGRA DE OURO: PATCH parcial nunca deixa documento em estado inválido
     const mergedValidity = {
       doesExpire: data.doesExpire ?? existingDocument.doesExpire ?? false,
       issuedAt: data.issuedAt !== undefined
         ? (data.issuedAt ? new Date(data.issuedAt) : null)
-        : existingDocument.issuedAt ?? null,
+        : (existingDocument.issuedAt ? new Date(existingDocument.issuedAt) : null),
       expiresAt: data.expiresAt !== undefined
         ? (data.expiresAt ? new Date(data.expiresAt) : null)
-        : existingDocument.expiresAt ?? null,
+        : (existingDocument.expiresAt ? new Date(existingDocument.expiresAt) : null),
     };
 
     // REGRA CRÍTICA: Se doesExpire=false, expiresAt DEVE ser null no estado final
@@ -557,12 +576,13 @@ export class DocumentService {
 
     // Se passou na validação, aplicar ao updateData
     // Aplicar sempre que houver campos de validade no patch ou quando doesExpire mudou
-    if (
+    const updateValidityFields =
       data.doesExpire !== undefined ||
       data.expiresAt !== undefined ||
       data.issuedAt !== undefined ||
-      mergedValidity.doesExpire !== (existingDocument.doesExpire ?? false)
-    ) {
+      mergedValidity.doesExpire !== (existingDocument.doesExpire ?? false);
+
+    if (updateValidityFields) {
       updateData.doesExpire = mergedValidity.doesExpire;
       updateData.issuedAt = mergedValidity.issuedAt;
       updateData.expiresAt = mergedValidity.expiresAt; // Já garantido como null se doesExpire=false
@@ -830,6 +850,7 @@ export class DocumentService {
   private mapToDocument(doc: {
     id: string;
     empresaId: string;
+    bidId?: string | null;
     name: string;
     filename: string;
     mimeType: string;
@@ -861,6 +882,7 @@ export class DocumentService {
     return {
       id: doc.id,
       empresaId: doc.empresaId,
+      bidId: doc.bidId || null,
       name: doc.name,
       filename: doc.filename,
       mimeType: doc.mimeType,
@@ -893,5 +915,68 @@ export class DocumentService {
         limit: 1000, // Limite alto para dashboard
       })
     ).data;
+  }
+
+  /**
+   * Vincula um documento a uma licitação
+   * Valida que ambos pertencem à mesma empresa
+   */
+  async attachToBid(documentId: string, bidId: string, empresaId: string): Promise<Document> {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+
+    // Verificar se a licitação existe e pertence ao tenant
+    const bid = await prismaWithTenant.bid.findUnique({
+      where: { id: bidId },
+    });
+
+    if (!bid || bid.empresaId !== empresaId) {
+      throw new NotFoundException(`Licitação com ID ${bidId} não encontrada`);
+    }
+
+    // Verificar se o documento existe e pertence ao tenant
+    const document = await prismaWithTenant.document.findUnique({
+      where: { id: documentId },
+    });
+
+    if (!document || document.empresaId !== empresaId) {
+      throw new NotFoundException(`Documento com ID ${documentId} não encontrado`);
+    }
+
+    // Atualizar documento vinculando à licitação
+    const updatedDocument = await prismaWithTenant.document.update({
+      where: { id: documentId },
+      data: { bidId },
+    });
+
+    return this.mapToDocument(updatedDocument);
+  }
+
+  /**
+   * Desvincula um documento de uma licitação
+   */
+  async detachFromBid(documentId: string, empresaId: string): Promise<Document> {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+
+    // Verificar se o documento existe e pertence ao tenant
+    const document = await prismaWithTenant.document.findUnique({
+      where: { id: documentId },
+    });
+
+    if (!document || document.empresaId !== empresaId) {
+      throw new NotFoundException(`Documento com ID ${documentId} não encontrado`);
+    }
+
+    // Se já não está vinculado, não faz nada
+    if (!document.bidId) {
+      return this.mapToDocument(document);
+    }
+
+    // Atualizar documento removendo vínculo com licitação
+    const updatedDocument = await prismaWithTenant.document.update({
+      where: { id: documentId },
+      data: { bidId: null },
+    });
+
+    return this.mapToDocument(updatedDocument);
   }
 }

--- a/apps/api/src/prisma/prisma-tenant.service.ts
+++ b/apps/api/src/prisma/prisma-tenant.service.ts
@@ -255,9 +255,15 @@ export class PrismaTenantService {
               }
               // Garantir que deletedAt seja null ao criar
               data.deletedAt = null;
-              // Remover relacionamento se existir (usar empresaId direto)
+              // Remover relacionamentos se existirem (usar IDs diretos)
               if (data.empresa) {
                 delete data.empresa;
+              }
+              if (data.uploader) {
+                delete data.uploader;
+              }
+              if (data.bid) {
+                delete data.bid;
               }
               args.data = data;
             }

--- a/packages/shared/src/schemas/document.ts
+++ b/packages/shared/src/schemas/document.ts
@@ -113,6 +113,7 @@ export const createDocumentSchema = z
       DocumentCategory.ADMINISTRATIVO,
       DocumentCategory.OUTROS,
     ]),
+    bidId: z.string().uuid().optional().nullable(), // Opcional: vincular a uma licitação
   })
   .merge(documentValidityBaseSchema.partial())
   .superRefine((data, ctx) => {
@@ -186,6 +187,7 @@ export const updateDocumentSchema = z
         DocumentCategory.OUTROS,
       ])
       .optional(),
+    bidId: z.string().uuid().optional().nullable(), // Opcional: vincular/desvincular de licitação
   })
   .merge(documentValidityPatchSchema);
 
@@ -215,6 +217,8 @@ export const documentSchema = z.object({
   uploadedBy: z.string().uuid(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  // Associação com licitação (opcional)
+  bidId: z.string().uuid().nullable(),
   // Campos de validade
   doesExpire: z.boolean(),
   issuedAt: z.string().datetime().nullable(),


### PR DESCRIPTION
- Adiciona campo bidId opcional na entidade Document
- Cria endpoints POST /documents/:id/attach e POST /documents/:id/detach
- Adiciona filtro bidId na listagem de documentos (GET /documents?bidId=...)
- Cria endpoint GET /bids/:id/documents para listar documentos da licitação
- Suporta vincular documento na criação (campo bidId no POST /documents)
- Suporta atualizar vínculo via PATCH /documents/:id
- Implementa validações de tenant (documento e licitação da mesma empresa)
- Adiciona auditoria específica para attach/detach
- Atualiza PrismaTenantService para suportar relacionamento Bid-Document
