### PR TITLE
feat: implementa templates de checklist por modalidade (F3-01)

### DIFF
--- a/apps/api/prisma/migrations/20260120192150_add_checklist_template/migration.sql
+++ b/apps/api/prisma/migrations/20260120192150_add_checklist_template/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "checklist_templates" (
+    "id" TEXT NOT NULL,
+    "empresaId" TEXT NOT NULL,
+    "modality" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "items" JSONB NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "checklist_templates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "checklist_templates_empresaId_idx" ON "checklist_templates"("empresaId");
+
+-- CreateIndex
+CREATE INDEX "checklist_templates_empresaId_modality_idx" ON "checklist_templates"("empresaId", "modality");
+
+-- CreateIndex
+CREATE INDEX "checklist_templates_empresaId_deletedAt_idx" ON "checklist_templates"("empresaId", "deletedAt");
+
+-- CreateIndex
+CREATE INDEX "checklist_templates_empresaId_modality_isActive_idx" ON "checklist_templates"("empresaId", "modality", "isActive");
+
+-- CreateIndex
+CREATE INDEX "checklist_templates_empresaId_modality_isDefault_idx" ON "checklist_templates"("empresaId", "modality", "isDefault");
+
+-- CreateIndex
+CREATE INDEX "checklist_templates_createdBy_idx" ON "checklist_templates"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "checklist_templates_deletedAt_idx" ON "checklist_templates"("deletedAt");
+
+-- AddForeignKey
+ALTER TABLE "checklist_templates" ADD CONSTRAINT "checklist_templates_empresaId_fkey" FOREIGN KEY ("empresaId") REFERENCES "empresas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "checklist_templates" ADD CONSTRAINT "checklist_templates_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -28,6 +28,8 @@ model Empresa {
   documents        Document[]
   // Relacionamento: Uma empresa tem muitas versões de documentos
   documentVersions DocumentVersion[]
+  // Relacionamento: Uma empresa tem muitos templates de checklist
+  checklistTemplates ChecklistTemplate[]
 
   @@index([deletedAt]) // Otimizar queries que filtram deletados
   @@map("empresas")
@@ -59,6 +61,8 @@ model User {
   uploadedDocuments        Document[]
   // Relacionamento: Um usuário pode fazer upload de várias versões de documentos
   uploadedDocumentVersions DocumentVersion[]
+  // Relacionamento: Um usuário pode criar vários templates de checklist
+  createdChecklistTemplates ChecklistTemplate[]
 
   @@index([email])
   @@index([empresaId])
@@ -194,4 +198,34 @@ model DocumentVersion {
   @@index([uploadedBy]) // Consultas por usuário que fez upload
   @@index([createdAt]) // Consultas ordenadas por data
   @@map("document_versions")
+}
+
+// Entidade ChecklistTemplate (Template de Checklist)
+model ChecklistTemplate {
+  id          String   @id @default(uuid())
+  empresaId   String // Multi-tenancy: isolamento por empresa
+  modality    String // Modalidade da licitação (PREGAO_ELETRONICO, CONCORRENCIA, DISPENSA, OUTRA)
+  name        String // Nome do template (ex: "Template Padrão - Pregão Eletrônico")
+  description String? // Descrição opcional do template
+  items       Json // Array de itens do checklist em JSON
+  isActive    Boolean  @default(true) // Se o template está ativo
+  isDefault   Boolean  @default(false) // Se é o template padrão para a modalidade
+  createdBy   String // ID do usuário que criou o template
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  deletedAt   DateTime? // Soft delete: quando não null, registro está deletado
+
+  // Relacionamento: Um template pertence a uma empresa
+  empresa Empresa @relation(fields: [empresaId], references: [id], onDelete: Cascade)
+  // Relacionamento: Um template foi criado por um usuário
+  creator User @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+
+  @@index([empresaId])
+  @@index([empresaId, modality]) // Consultas por empresa e modalidade
+  @@index([empresaId, deletedAt]) // Índice composto para queries de tenant + soft delete
+  @@index([empresaId, modality, isActive]) // Consultas por empresa, modalidade e status ativo
+  @@index([empresaId, modality, isDefault]) // Consultas por empresa, modalidade e padrão
+  @@index([createdBy])
+  @@index([deletedAt]) // Otimizar queries que filtram deletados
+  @@map("checklist_templates")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuditLogModule } from "./audit-log/audit-log.module";
 import { CommonModule } from "./common/common.module";
 import { BidModule } from "./bid/bid.module";
 import { DocumentModule } from "./document/document.module";
+import { ChecklistTemplateModule } from "./checklist-template/checklist-template.module";
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { DocumentModule } from "./document/document.module";
     CommonModule,
     BidModule,
     DocumentModule,
+    ChecklistTemplateModule,
   ],
   controllers: [AppController, HealthController],
   providers: [AppService],

--- a/apps/api/src/checklist-template/checklist-template.controller.ts
+++ b/apps/api/src/checklist-template/checklist-template.controller.ts
@@ -1,0 +1,253 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  BadRequestException,
+  UseGuards,
+  UseInterceptors,
+  Req,
+} from "@nestjs/common";
+import { ChecklistTemplateService } from "./checklist-template.service";
+import { SoftDeleteService } from "../common/services/soft-delete.service";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { RolesGuard } from "../common/guards/roles.guard";
+import { Roles } from "../common/decorators/roles.decorator";
+import { Tenant } from "../common/decorators/tenant.decorator";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { Audit } from "../audit-log/decorators/audit.decorator";
+import { AuditInterceptor } from "../audit-log/interceptors/audit.interceptor";
+import {
+  createChecklistTemplateSchema,
+  updateChecklistTemplateSchema,
+  type ChecklistTemplate,
+  type User,
+  UserRole,
+} from "@licitafacil/shared";
+import type { Request } from "express";
+
+/**
+ * Controller para gerenciar templates de checklist
+ *
+ * Todos os endpoints requerem autenticação e isolamento por tenant
+ */
+@Controller("checklist-templates")
+@UseGuards(JwtAuthGuard, RolesGuard)
+@UseInterceptors(AuditInterceptor)
+export class ChecklistTemplateController {
+  constructor(
+    private readonly checklistTemplateService: ChecklistTemplateService,
+    private readonly softDeleteService: SoftDeleteService,
+  ) {}
+
+  /**
+   * Cria um novo template de checklist
+   * POST /checklist-templates
+   *
+   * Permissão: ADMIN
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @Roles(UserRole.ADMIN)
+  @Audit({ action: "checklist-template.create", resourceType: "ChecklistTemplate" })
+  async create(
+    @Body() body: unknown,
+    @Tenant() empresaId: string,
+    @CurrentUser() user: User,
+    @Req() _request: Request,
+  ): Promise<ChecklistTemplate> {
+    // Validar dados de entrada com Zod
+    const result = createChecklistTemplateSchema.safeParse(body);
+
+    if (!result.success) {
+      throw new BadRequestException({
+        message: "Dados inválidos",
+        errors: result.error.errors,
+      });
+    }
+
+    return this.checklistTemplateService.create(result.data, empresaId, user.id);
+  }
+
+  /**
+   * Lista templates com filtros e paginação
+   * GET /checklist-templates
+   *
+   * Query params:
+   * - page: número da página (default: 1)
+   * - limit: itens por página (default: 20, max: 100)
+   * - modality: filtrar por modalidade
+   * - isActive: filtrar por status ativo (true/false)
+   * - isDefault: filtrar por template padrão (true/false)
+   * - search: buscar por nome
+   *
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async findAll(
+    @Tenant() empresaId: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+    @Query("modality") modality?: string,
+    @Query("isActive") isActive?: string,
+    @Query("isDefault") isDefault?: string,
+    @Query("search") search?: string,
+  ) {
+    return this.checklistTemplateService.findAll({
+      empresaId,
+      page: page ? parseInt(page, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      modality,
+      isActive: isActive === "true" ? true : isActive === "false" ? false : undefined,
+      isDefault: isDefault === "true" ? true : isDefault === "false" ? false : undefined,
+      search,
+    });
+  }
+
+  /**
+   * Busca um template específico por ID
+   * GET /checklist-templates/:id
+   *
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Get(":id")
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async findOne(
+    @Param("id") id: string,
+    @Tenant() empresaId: string,
+  ): Promise<ChecklistTemplate> {
+    return this.checklistTemplateService.findOne(id, empresaId);
+  }
+
+  /**
+   * Atualiza um template de checklist
+   * PATCH /checklist-templates/:id
+   *
+   * Permissão: ADMIN
+   */
+  @Patch(":id")
+  @Roles(UserRole.ADMIN)
+  @Audit({ action: "checklist-template.update", resourceType: "ChecklistTemplate", captureResourceId: true })
+  async update(
+    @Param("id") id: string,
+    @Body() body: unknown,
+    @Tenant() empresaId: string,
+    @CurrentUser() _user: User,
+    @Req() _request: Request,
+  ): Promise<ChecklistTemplate> {
+    // Validar dados de entrada com Zod
+    const result = updateChecklistTemplateSchema.safeParse(body);
+
+    if (!result.success) {
+      throw new BadRequestException({
+        message: "Dados inválidos",
+        errors: result.error.errors,
+      });
+    }
+
+    return this.checklistTemplateService.update(id, result.data, empresaId);
+  }
+
+  /**
+   * Remove um template (soft delete)
+   * DELETE /checklist-templates/:id
+   *
+   * Permissão: ADMIN
+   */
+  @Delete(":id")
+  @HttpCode(HttpStatus.OK)
+  @Roles(UserRole.ADMIN)
+  async remove(
+    @Param("id") id: string,
+    @Tenant() empresaId: string,
+    @CurrentUser() user: User,
+    @Req() request: Request,
+  ) {
+    // Validar que o template existe antes de deletar
+    await this.checklistTemplateService.remove(id, empresaId);
+
+    // Fazer soft delete com auditoria
+    await this.softDeleteService.delete("checklistTemplate", id, empresaId, user.id, request);
+
+    return {
+      message: "Template de checklist deletado com sucesso",
+      id,
+    };
+  }
+
+  /**
+   * Restaura um template deletado
+   * POST /checklist-templates/:id/restore
+   *
+   * Permissão: ADMIN
+   */
+  @Post(":id/restore")
+  @HttpCode(HttpStatus.OK)
+  @Roles(UserRole.ADMIN)
+  async restore(
+    @Param("id") id: string,
+    @Tenant() empresaId: string,
+    @CurrentUser() user: User,
+    @Req() request: Request,
+  ) {
+    await this.softDeleteService.restore("checklistTemplate", id, empresaId, user.id, request);
+
+    return {
+      message: "Template de checklist restaurado com sucesso",
+      id,
+    };
+  }
+
+  /**
+   * Busca templates por modalidade
+   * GET /checklist-templates/by-modality/:modality
+   *
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Get("by-modality/:modality")
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async findByModality(
+    @Param("modality") modality: string,
+    @Tenant() empresaId: string,
+  ): Promise<ChecklistTemplate[]> {
+    return this.checklistTemplateService.findByModality(modality, empresaId);
+  }
+
+  /**
+   * Busca templates padrão por modalidade
+   * GET /checklist-templates/default/:modality
+   *
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Get("default/:modality")
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async findDefaultByModality(
+    @Param("modality") modality: string,
+    @Tenant() empresaId: string,
+  ): Promise<ChecklistTemplate[]> {
+    return this.checklistTemplateService.findDefaultByModality(modality, empresaId);
+  }
+
+  /**
+   * Conta total de templates da empresa
+   * GET /checklist-templates/stats/count
+   *
+   * Permissão: ADMIN e COLABORADOR
+   */
+  @Get("stats/count")
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async count(@Tenant() empresaId: string) {
+    const total = await this.checklistTemplateService.count(empresaId);
+    return {
+      total,
+      empresaId,
+    };
+  }
+}

--- a/apps/api/src/checklist-template/checklist-template.module.ts
+++ b/apps/api/src/checklist-template/checklist-template.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { ChecklistTemplateController } from "./checklist-template.controller";
+import { ChecklistTemplateService } from "./checklist-template.service";
+import { PrismaModule } from "../prisma/prisma.module";
+import { CommonModule } from "../common/common.module";
+import { AuditLogModule } from "../audit-log/audit-log.module";
+
+@Module({
+  imports: [PrismaModule, CommonModule, AuditLogModule],
+  controllers: [ChecklistTemplateController],
+  providers: [ChecklistTemplateService],
+  exports: [ChecklistTemplateService],
+})
+export class ChecklistTemplateModule {}

--- a/apps/api/src/checklist-template/checklist-template.service.ts
+++ b/apps/api/src/checklist-template/checklist-template.service.ts
@@ -1,0 +1,312 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common";
+import { PrismaTenantService } from "../prisma/prisma-tenant.service";
+import {
+  type CreateChecklistTemplateInput,
+  type UpdateChecklistTemplateInput,
+  type ChecklistTemplate,
+  type ChecklistItem,
+} from "@licitafacil/shared";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Interface para filtros de listagem de templates
+ */
+export interface ListChecklistTemplatesFilters {
+  empresaId: string;
+  modality?: string;
+  isActive?: boolean;
+  isDefault?: boolean;
+  search?: string; // Busca por nome
+  page?: number;
+  limit?: number;
+}
+
+@Injectable()
+export class ChecklistTemplateService {
+  constructor(
+    private readonly prismaTenant: PrismaTenantService,
+  ) {}
+
+  /**
+   * Valida e garante que todos os itens tenham UUID
+   */
+  private ensureItemsHaveIds(items: Array<Partial<ChecklistItem> & { title: string; order: number }>): ChecklistItem[] {
+    return items.map((item) => ({
+      ...item,
+      id: item.id || uuidv4(),
+    })) as ChecklistItem[];
+  }
+
+  /**
+   * Cria um novo template de checklist
+   */
+  async create(
+    data: CreateChecklistTemplateInput,
+    empresaId: string,
+    userId: string,
+  ): Promise<ChecklistTemplate> {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+
+    // Garantir que todos os itens tenham IDs
+    const itemsWithIds = this.ensureItemsHaveIds(data.items);
+
+    // Validar que não há IDs duplicados
+    const itemIds = itemsWithIds.map((item) => item.id);
+    const uniqueIds = new Set(itemIds);
+    if (itemIds.length !== uniqueIds.size) {
+      throw new BadRequestException("Itens do checklist não podem ter IDs duplicados");
+    }
+
+    // Validar que as ordens são únicas
+    const orders = itemsWithIds.map((item) => item.order);
+    const uniqueOrders = new Set(orders);
+    if (orders.length !== uniqueOrders.size) {
+      throw new BadRequestException("Ordens dos itens devem ser únicas");
+    }
+
+    const template = await prismaWithTenant.checklistTemplate.create({
+      data: {
+        modality: data.modality,
+        name: data.name,
+        description: data.description ?? null,
+        items: itemsWithIds as any,
+        isActive: data.isActive ?? true,
+        isDefault: data.isDefault ?? false,
+        createdBy: userId,
+        empresaId,
+      },
+    });
+
+    return this.mapToChecklistTemplate(template);
+  }
+
+  /**
+   * Lista templates com filtros e paginação
+   */
+  async findAll(filters: ListChecklistTemplatesFilters) {
+    const prismaWithTenant = this.prismaTenant.forTenant(filters.empresaId);
+
+    const page = filters.page ?? 1;
+    const limit = Math.min(filters.limit ?? 20, 100); // Máximo 100 por página
+    const skip = (page - 1) * limit;
+
+    // Construir filtros do Prisma
+    const where: any = {
+      empresaId: filters.empresaId,
+    };
+
+    if (filters.modality) {
+      where.modality = filters.modality;
+    }
+
+    if (filters.isActive !== undefined) {
+      where.isActive = filters.isActive;
+    }
+
+    if (filters.isDefault !== undefined) {
+      where.isDefault = filters.isDefault;
+    }
+
+    // Busca por nome (case insensitive)
+    if (filters.search) {
+      where.name = { contains: filters.search, mode: "insensitive" };
+    }
+
+    // Buscar templates e total
+    const [templates, total] = await Promise.all([
+      prismaWithTenant.checklistTemplate.findMany({
+        where,
+        orderBy: [
+          { modality: "asc" },
+          { isDefault: "desc" },
+          { name: "asc" },
+        ],
+        skip,
+        take: limit,
+      }),
+      prismaWithTenant.checklistTemplate.count({ where }),
+    ]);
+
+    return {
+      data: templates.map((template) => this.mapToChecklistTemplate(template)),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  /**
+   * Busca um template por ID (com filtro de tenant)
+   */
+  async findOne(id: string, empresaId: string): Promise<ChecklistTemplate> {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+    const template = await prismaWithTenant.checklistTemplate.findUnique({
+      where: { id },
+    });
+
+    if (!template) {
+      throw new NotFoundException(`Template de checklist com ID ${id} não encontrado`);
+    }
+
+    return this.mapToChecklistTemplate(template);
+  }
+
+  /**
+   * Atualiza um template de checklist
+   */
+  async update(
+    id: string,
+    data: UpdateChecklistTemplateInput,
+    empresaId: string,
+  ): Promise<ChecklistTemplate> {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+
+    // Verificar se o template existe
+    const existingTemplate = await prismaWithTenant.checklistTemplate.findUnique({
+      where: { id },
+    });
+
+    if (!existingTemplate) {
+      throw new NotFoundException(`Template de checklist com ID ${id} não encontrado`);
+    }
+
+    // Preparar dados de atualização
+    const updateData: any = {};
+
+    if (data.modality !== undefined) {
+      updateData.modality = data.modality;
+    }
+
+    if (data.name !== undefined) {
+      updateData.name = data.name;
+    }
+
+    if (data.description !== undefined) {
+      updateData.description = data.description ?? null;
+    }
+
+    if (data.isActive !== undefined) {
+      updateData.isActive = data.isActive;
+    }
+
+    if (data.isDefault !== undefined) {
+      updateData.isDefault = data.isDefault;
+    }
+
+    // Se items foram fornecidos, validar e processar
+    if (data.items !== undefined) {
+      // Garantir que todos os itens tenham IDs
+      const itemsWithIds = this.ensureItemsHaveIds(data.items);
+
+      // Validar que não há IDs duplicados
+      const itemIds = itemsWithIds.map((item) => item.id);
+      const uniqueIds = new Set(itemIds);
+      if (itemIds.length !== uniqueIds.size) {
+        throw new BadRequestException("Itens do checklist não podem ter IDs duplicados");
+      }
+
+      // Validar que as ordens são únicas
+      const orders = itemsWithIds.map((item) => item.order);
+      const uniqueOrders = new Set(orders);
+      if (orders.length !== uniqueOrders.size) {
+        throw new BadRequestException("Ordens dos itens devem ser únicas");
+      }
+
+      updateData.items = itemsWithIds as any;
+    }
+
+    // Atualizar template
+    const updatedTemplate = await prismaWithTenant.checklistTemplate.update({
+      where: { id },
+      data: updateData,
+    });
+
+    return this.mapToChecklistTemplate(updatedTemplate);
+  }
+
+  /**
+   * Remove um template (soft delete é feito via SoftDeleteService)
+   * Este método não deve ser usado diretamente
+   */
+  async remove(id: string, empresaId: string): Promise<void> {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+
+    const template = await prismaWithTenant.checklistTemplate.findUnique({
+      where: { id },
+    });
+
+    if (!template) {
+      throw new NotFoundException(`Template de checklist com ID ${id} não encontrado`);
+    }
+
+    // Soft delete é feito via SoftDeleteService
+    // Este método apenas valida que o template existe
+  }
+
+  /**
+   * Mapeia entidade Prisma para ChecklistTemplate
+   */
+  private mapToChecklistTemplate(template: {
+    id: string;
+    empresaId: string;
+    modality: string;
+    name: string;
+    description: string | null;
+    items: any; // JSON
+    isActive: boolean;
+    isDefault: boolean;
+    createdBy: string;
+    createdAt: Date;
+    updatedAt: Date;
+    deletedAt: Date | null;
+  }): ChecklistTemplate {
+    return {
+      id: template.id,
+      empresaId: template.empresaId,
+      modality: template.modality,
+      name: template.name,
+      description: template.description,
+      items: Array.isArray(template.items) ? template.items : [],
+      isActive: template.isActive,
+      isDefault: template.isDefault,
+      createdBy: template.createdBy,
+      createdAt: template.createdAt.toISOString(),
+      updatedAt: template.updatedAt.toISOString(),
+      deletedAt: template.deletedAt?.toISOString() ?? null,
+    };
+  }
+
+  /**
+   * Busca templates por modalidade
+   */
+  async findByModality(modality: string, empresaId: string) {
+    return (await this.findAll({ empresaId, modality, page: 1, limit: 100 })).data;
+  }
+
+  /**
+   * Busca templates padrão por modalidade
+   */
+  async findDefaultByModality(modality: string, empresaId: string) {
+    return (
+      await this.findAll({
+        empresaId,
+        modality,
+        isDefault: true,
+        isActive: true,
+        page: 1,
+        limit: 100,
+      })
+    ).data;
+  }
+
+  /**
+   * Conta total de templates da empresa
+   */
+  async count(empresaId: string): Promise<number> {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+    return prismaWithTenant.checklistTemplate.count();
+  }
+}

--- a/apps/api/src/common/services/soft-delete.service.ts
+++ b/apps/api/src/common/services/soft-delete.service.ts
@@ -5,7 +5,7 @@ import { AuditLogService } from "../../audit-log/audit-log.service";
 /**
  * Tipos de recursos que podem ser deletados via soft delete
  */
-export type SoftDeletableResource = "user" | "empresa" | "bid" | "document";
+export type SoftDeletableResource = "user" | "empresa" | "bid" | "document" | "checklistTemplate";
 
 /**
  * Interface para metadata sanitizada do recurso deletado
@@ -40,6 +40,7 @@ export class SoftDeleteService {
       empresa: "Empresa",
       bid: "Bid",
       document: "Document",
+      checklistTemplate: "ChecklistTemplate",
     };
     return mapping[resource];
   }

--- a/apps/api/src/prisma/prisma-tenant.service.ts
+++ b/apps/api/src/prisma/prisma-tenant.service.ts
@@ -434,6 +434,75 @@ export class PrismaTenantService {
             );
           },
         },
+        checklistTemplate: {
+          async findMany({ args, query }) {
+            args.where = addTenantAndSoftDeleteFilter(args?.where);
+            return query(args);
+          },
+          async findFirst({ args, query }) {
+            args.where = addTenantAndSoftDeleteFilter(args?.where);
+            return query(args);
+          },
+          async findUnique({ args, query }) {
+            // findUnique usa where ou id direto
+            const result = await query(args);
+            // Verificar se o resultado pertence ao tenant e não está deletado
+            if (!result || result.empresaId !== empresaId || result.deletedAt !== null) {
+              return null;
+            }
+            return result;
+          },
+          async create({ args, query }) {
+            if (args?.data) {
+              // Garantir empresaId sem conflitar com relacionamento 'empresa'
+              const data = args.data as any;
+              if (!data.empresaId) {
+                data.empresaId = empresaId;
+              }
+              // Garantir que deletedAt seja null ao criar
+              data.deletedAt = null;
+              // Remover relacionamentos se existirem (usar IDs diretos)
+              if (data.empresa) {
+                delete data.empresa;
+              }
+              if (data.creator) {
+                delete data.creator;
+              }
+              args.data = data;
+            }
+            return query(args);
+          },
+          async update({ args, query }) {
+            // Para update, não podemos modificar o where (precisa ser unique)
+            // Então fazemos a query e validamos o resultado
+            const result = await query(args);
+            if (!result || result.empresaId !== empresaId || result.deletedAt !== null) {
+              return null;
+            }
+            return result;
+          },
+          async updateMany({ args, query }) {
+            args.where = addTenantAndSoftDeleteFilter(args?.where);
+            return query(args);
+          },
+          async delete({ args: _args, query: _query }) {
+            // Hard delete não permitido via tenant service
+            // Usar SoftDeleteService para soft delete
+            throw new Error(
+              "Hard delete não é permitido. Use SoftDeleteService para realizar soft delete.",
+            );
+          },
+          async deleteMany({ args: _args, query: _query }) {
+            // Hard delete não permitido via tenant service
+            throw new Error(
+              "Hard delete não é permitido. Use SoftDeleteService para realizar soft delete.",
+            );
+          },
+          async count({ args, query }) {
+            args.where = addTenantAndSoftDeleteFilter(args?.where);
+            return query(args);
+          },
+        },
       },
     });
   }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from "./schemas/bid";
 export * from "./schemas/empresa";
 export * from "./schemas/user";
 export * from "./schemas/document";
+export * from "./schemas/checklist-template";
 
 // Enums
 export * from "./enums/user-role.enum";

--- a/packages/shared/src/schemas/checklist-template.ts
+++ b/packages/shared/src/schemas/checklist-template.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import { BidModality } from "./bid";
+
+/**
+ * Categorias de itens do checklist
+ */
+export const ChecklistItemCategory = {
+  DOCUMENTACAO: "DOCUMENTACAO",
+  FINANCEIRO: "FINANCEIRO",
+  TECNICO: "TECNICO",
+  JURIDICO: "JURIDICO",
+  ADMINISTRATIVO: "ADMINISTRATIVO",
+  OUTROS: "OUTROS",
+} as const;
+
+/**
+ * Schema para um item do checklist (input - ID opcional)
+ */
+export const checklistItemInputSchema = z.object({
+  id: z.string().uuid().optional(),
+  title: z.string().min(1, "Título é obrigatório").max(500, "Título muito longo"),
+  description: z.string().max(1000, "Descrição muito longa").optional().nullable(),
+  required: z.boolean().default(false),
+  order: z.number().int().positive("Ordem deve ser um número positivo"),
+  category: z
+    .enum([
+      ChecklistItemCategory.DOCUMENTACAO,
+      ChecklistItemCategory.FINANCEIRO,
+      ChecklistItemCategory.TECNICO,
+      ChecklistItemCategory.JURIDICO,
+      ChecklistItemCategory.ADMINISTRATIVO,
+      ChecklistItemCategory.OUTROS,
+    ])
+    .optional()
+    .nullable(),
+});
+
+/**
+ * Schema para um item do checklist (output - ID obrigatório)
+ */
+export const checklistItemSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().min(1, "Título é obrigatório").max(500, "Título muito longo"),
+  description: z.string().max(1000, "Descrição muito longa").optional().nullable(),
+  required: z.boolean().default(false),
+  order: z.number().int().positive("Ordem deve ser um número positivo"),
+  category: z
+    .enum([
+      ChecklistItemCategory.DOCUMENTACAO,
+      ChecklistItemCategory.FINANCEIRO,
+      ChecklistItemCategory.TECNICO,
+      ChecklistItemCategory.JURIDICO,
+      ChecklistItemCategory.ADMINISTRATIVO,
+      ChecklistItemCategory.OUTROS,
+    ])
+    .optional()
+    .nullable(),
+});
+
+/**
+ * Schema de validação para criar um template de checklist
+ */
+export const createChecklistTemplateSchema = z.object({
+  modality: z.enum([
+    BidModality.PREGAO_ELETRONICO,
+    BidModality.CONCORRENCIA,
+    BidModality.DISPENSA,
+    BidModality.OUTRA,
+  ]),
+  name: z.string().min(1, "Nome é obrigatório").max(200, "Nome muito longo"),
+  description: z.string().max(500, "Descrição muito longa").optional().nullable(),
+  items: z
+    .array(checklistItemInputSchema)
+    .min(1, "Deve ter pelo menos um item no checklist"),
+  isActive: z.boolean().default(true),
+  isDefault: z.boolean().default(false),
+});
+
+/**
+ * Schema de validação para atualizar um template de checklist
+ */
+export const updateChecklistTemplateSchema = z.object({
+  modality: z
+    .enum([
+      BidModality.PREGAO_ELETRONICO,
+      BidModality.CONCORRENCIA,
+      BidModality.DISPENSA,
+      BidModality.OUTRA,
+    ])
+    .optional(),
+  name: z.string().min(1, "Nome é obrigatório").max(200, "Nome muito longo").optional(),
+  description: z.string().max(500, "Descrição muito longa").optional().nullable(),
+  items: z
+    .array(checklistItemInputSchema)
+    .min(1, "Deve ter pelo menos um item no checklist")
+    .optional(),
+  isActive: z.boolean().optional(),
+  isDefault: z.boolean().optional(),
+});
+
+/**
+ * Schema de validação para ChecklistTemplate completo
+ */
+export const checklistTemplateSchema = z.object({
+  id: z.string().uuid(),
+  empresaId: z.string().uuid(),
+  modality: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  items: z.array(checklistItemSchema),
+  isActive: z.boolean(),
+  isDefault: z.boolean(),
+  createdBy: z.string().uuid(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  deletedAt: z.string().datetime().nullable(),
+});
+
+export type ChecklistTemplate = z.infer<typeof checklistTemplateSchema>;
+export type ChecklistItem = z.infer<typeof checklistItemSchema>;
+export type CreateChecklistTemplateInput = z.infer<typeof createChecklistTemplateSchema>;
+export type UpdateChecklistTemplateInput = z.infer<typeof updateChecklistTemplateSchema>;
+export type ChecklistItemCategoryType = keyof typeof ChecklistItemCategory;


### PR DESCRIPTION
- Adiciona model ChecklistTemplate no schema Prisma
- Cria schemas Zod para validação de templates e itens
- Implementa ChecklistTemplateService com CRUD completo
- Adiciona endpoints REST para gerenciamento de templates
- Suporta múltiplos templates por modalidade com campo isDefault
- Permite categorização de itens (DOCUMENTACAO, FINANCEIRO, TECNICO, etc.)
- Gera IDs automaticamente para itens quando não fornecidos
- Integra multi-tenancy, RBAC e soft delete
- Adiciona auditoria automática para todas as operações
- Implementa filtros por modalidade, status ativo e template padrão
