### PR TITLE
fix(ci): add Prisma generate and build steps to pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           cache: pnpm
       - name: Install
         run: pnpm install --frozen-lockfile
+      - name: Prisma generate
+        run: pnpm --filter @licitafacil/api exec prisma generate
+      - name: Build
+        run: pnpm run build
       - name: Lint
         run: pnpm lint
       - name: Typecheck


### PR DESCRIPTION
- Run prisma generate before build so Prisma client includes all models (Alert, Plano)
- Add build step to CI to catch API build failures
- Ensures main stays buildable after merges

## Descricao
<!-- Resuma as mudancas deste PR -->

## Issue Relacionada
<!-- Closes #1 -->

## Tipo de Mudanca
- [ ] Bug fix
- [ ] Nova feature
- [ ] Breaking change
- [ ] Documentacao
- [ ] Refactor
- [ ] Tests
- [ ] Chore

## Como Testar
1.
2.
3.

## Checklist
- [ ] Codigo segue padroes do projeto
- [ ] Self-review realizado
- [ ] Documentacao atualizada (se aplicavel)
- [ ] Sem novos warnings
- [ ] `pnpm typecheck` ok (se existir)
- [ ] `pnpm lint` ok (se existir)
- [ ] `pnpm build` ok (se existir)
