### PR TITLE
feat(F22-01): LicitaIA — chat com edital via GPT-4o

### DIFF
--- a/apps/api/prisma/migrations/20260226150040_add_chat_historico/migration.sql
+++ b/apps/api/prisma/migrations/20260226150040_add_chat_historico/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "chat_historicos" (
+    "id" TEXT NOT NULL,
+    "empresaId" TEXT NOT NULL,
+    "bidId" TEXT NOT NULL,
+    "pergunta" TEXT NOT NULL,
+    "resposta" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "chat_historicos_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "chat_historicos_empresaId_bidId_idx" ON "chat_historicos"("empresaId", "bidId");
+
+-- AddForeignKey
+ALTER TABLE "chat_historicos" ADD CONSTRAINT "chat_historicos_empresaId_fkey" FOREIGN KEY ("empresaId") REFERENCES "empresas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "chat_historicos" ADD CONSTRAINT "chat_historicos_bidId_fkey" FOREIGN KEY ("bidId") REFERENCES "bids"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -48,6 +48,8 @@ model Empresa {
   peticoes           Peticao[]
   // Relacionamento: Uma empresa tem muitas simulações de disputa
   simulacoes         SimulacaoDisputa[]
+  // Relacionamento: Uma empresa tem muitos históricos de chat com edital
+  chatHistoricos     ChatHistorico[]
 
   @@index([deletedAt]) // Otimizar queries que filtram deletados
   @@map("empresas")
@@ -153,6 +155,8 @@ model Bid {
   peticoes        Peticao[]
   // Relacionamento: Uma licitação pode ter várias simulações de disputa
   simulacoes      SimulacaoDisputa[]
+  // Relacionamento: Uma licitação pode ter vários históricos de chat com edital
+  chatHistoricos  ChatHistorico[]
 
   @@index([empresaId])
   @@index([empresaId, operationalState]) // Consultas por empresa e estado operacional
@@ -239,6 +243,21 @@ model SimulacaoDisputa {
 
   @@index([empresaId, bidId, createdAt(sort: Desc)])
   @@map("simulacoes_disputa")
+}
+
+model ChatHistorico {
+  id        String   @id @default(cuid())
+  empresaId String
+  bidId     String
+  pergunta  String   @db.Text
+  resposta  String   @db.Text
+  createdAt DateTime @default(now())
+
+  empresa Empresa @relation(fields: [empresaId], references: [id], onDelete: Cascade)
+  bid     Bid     @relation(fields: [bidId], references: [id], onDelete: Cascade)
+
+  @@index([empresaId, bidId])
+  @@map("chat_historicos")
 }
 
 // Entidade Document (Documento)

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -163,6 +163,49 @@ export class AiService {
     }
   }
 
+  async chatComEdital(analiseJson: string, pergunta: string): Promise<string> {
+    const prompt = `SISTEMA:
+Você é um assistente especializado em licitações públicas brasileiras,
+com profundo conhecimento da Lei 14.133/2021, Lei 8.666/93 e demais
+normas de contratação pública.
+Sua função é responder perguntas sobre o edital analisado abaixo.
+REGRAS OBRIGATÓRIAS:
+
+Responda APENAS com base nas informações presentes na análise do edital
+Se a informação não estiver na análise, diga claramente:
+"Esta informação não consta na análise do edital disponível."
+Seja objetivo e direto — máximo 3 parágrafos por resposta
+Use linguagem clara, sem jargões desnecessários
+Nunca invente valores, datas ou requisitos
+
+ANÁLISE DO EDITAL:
+${analiseJson}
+PERGUNTA DO USUÁRIO:
+${pergunta}`;
+
+    this.logger.log("Chamando OpenAI GPT-4o para chat com edital...");
+    const completion = await this.openai.chat.completions.create({
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      temperature: 0.1,
+      max_tokens: 1024,
+    });
+
+    const resposta = completion.choices[0].message.content?.trim();
+    if (!resposta) {
+      throw new InternalServerErrorException(
+        "IA não retornou resposta para a pergunta",
+      );
+    }
+
+    return resposta;
+  }
+
   private truncarTexto(texto: string, maxCaracteres: number): string {
     if (texto.length <= maxCaracteres) {
       return texto;

--- a/apps/api/src/bid/bid.controller.ts
+++ b/apps/api/src/bid/bid.controller.ts
@@ -42,6 +42,13 @@ import {
   UserRole,
 } from "@licitafacil/shared";
 import type { Request } from "express";
+import { ChatPerguntaDto } from "./dto/chat-pergunta.dto";
+
+interface AuthenticatedRequest extends Request {
+  user?: {
+    empresaId?: string;
+  };
+}
 
 /**
  * Controller para gerenciar licitações
@@ -568,5 +575,37 @@ export class BidController {
     pdf: Express.Multer.File,
   ) {
     return this.bidService.analisarEdital(id, empresaId, pdf);
+  }
+
+  @Post(":id/chat")
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async chat(
+    @Param("id") id: string,
+    @Body() dto: ChatPerguntaDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    const empresaId = req.user?.empresaId;
+    if (!empresaId) {
+      throw new BadRequestException("Empresa não identificada no token");
+    }
+
+    return this.bidService.chatComEdital(id, dto.pergunta, empresaId);
+  }
+
+  @Get(":id/chat/historico")
+  @UseGuards(JwtAuthGuard)
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async chatHistorico(
+    @Param("id") id: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    const empresaId = req.user?.empresaId;
+    if (!empresaId) {
+      throw new BadRequestException("Empresa não identificada no token");
+    }
+
+    return this.bidService.getChatHistorico(id, empresaId);
   }
 }

--- a/apps/api/src/bid/bid.service.ts
+++ b/apps/api/src/bid/bid.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
 import { PrismaTenantService } from "../prisma/prisma-tenant.service";
 import { AiService } from "../ai/ai.service";
@@ -341,5 +341,69 @@ export class BidService {
     );
 
     return resultado;
+  }
+
+  async chatComEdital(bidId: string, pergunta: string, empresaId: string) {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+
+    await this.findOne(bidId, empresaId);
+
+    const editalAnalise = await prismaWithTenant.editalAnalise.findFirst({
+      where: { bidId },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (
+      !editalAnalise ||
+      editalAnalise.status !== "CONCLUIDA" ||
+      !editalAnalise.resultado
+    ) {
+      throw new BadRequestException("ANALISE_NAO_ENCONTRADA");
+    }
+
+    const analiseJson = JSON.stringify(editalAnalise.resultado);
+    const resposta = await this.aiService.chatComEdital(analiseJson, pergunta);
+
+    const chat = await prismaWithTenant.chatHistorico.create({
+      data: {
+        empresaId,
+        bidId,
+        pergunta,
+        resposta,
+      },
+    });
+
+    return {
+      resposta: chat.resposta,
+      pergunta: chat.pergunta,
+      createdAt: chat.createdAt,
+    };
+  }
+
+  async getChatHistorico(bidId: string, empresaId: string) {
+    const prismaWithTenant = this.prismaTenant.forTenant(empresaId);
+
+    await this.findOne(bidId, empresaId);
+
+    const editalAnalise = await prismaWithTenant.editalAnalise.findFirst({
+      where: { bidId },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (
+      !editalAnalise ||
+      editalAnalise.status !== "CONCLUIDA" ||
+      !editalAnalise.resultado
+    ) {
+      throw new BadRequestException("ANALISE_NAO_ENCONTRADA");
+    }
+
+    const historicoDesc = await prismaWithTenant.chatHistorico.findMany({
+      where: { bidId },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    });
+
+    return historicoDesc.reverse();
   }
 }

--- a/apps/api/src/bid/dto/chat-pergunta.dto.ts
+++ b/apps/api/src/bid/dto/chat-pergunta.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, MaxLength, MinLength } from "class-validator";
+
+export class ChatPerguntaDto {
+  @IsString()
+  @MinLength(3)
+  @MaxLength(1000)
+  pergunta!: string;
+}

--- a/apps/web/src/app/licitacoes/[id]/page.tsx
+++ b/apps/web/src/app/licitacoes/[id]/page.tsx
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   Scale,
   Swords,
+  MessageCircle,
 } from "lucide-react";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
@@ -242,7 +243,7 @@ export default function LicitacaoDetailPage() {
         </div>
 
         {/* Ações da licitação: Prazos, Checklist */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-8">
           <Link href={`/licitacoes/${id}/prazos`}>
             <Card className="shadow-sm border-gray-200 dark:border-gray-700 hover:border-emerald-500/50 hover:shadow-md transition-all cursor-pointer group h-full">
               <CardContent className="pt-6 pb-6 flex items-center justify-between">
@@ -301,6 +302,22 @@ export default function LicitacaoDetailPage() {
                   <div>
                     <h3 className="font-heading font-semibold text-gray-900 dark:text-gray-100 group-hover:text-emerald-700 dark:group-hover:text-emerald-400">Disputa</h3>
                     <p className="text-sm text-gray-500 dark:text-gray-400">Simule lances e acompanhe o histórico da disputa</p>
+                  </div>
+                </div>
+                <ChevronRight className="w-5 h-5 text-gray-400 dark:text-gray-500 group-hover:text-emerald-500 shrink-0" />
+              </CardContent>
+            </Card>
+          </Link>
+          <Link href={`/licitacoes/${id}/perguntas`}>
+            <Card className="shadow-sm border-gray-200 dark:border-gray-700 hover:border-emerald-500/50 hover:shadow-md transition-all cursor-pointer group h-full">
+              <CardContent className="pt-6 pb-6 flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 group-hover:bg-emerald-500/20 transition-colors">
+                    <MessageCircle className="w-6 h-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-heading font-semibold text-gray-900 dark:text-gray-100 group-hover:text-emerald-700 dark:group-hover:text-emerald-400">Perguntas</h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Faça perguntas sobre o edital usando IA</p>
                   </div>
                 </div>
                 <ChevronRight className="w-5 h-5 text-gray-400 dark:text-gray-500 group-hover:text-emerald-500 shrink-0" />

--- a/apps/web/src/app/licitacoes/[id]/perguntas/page.tsx
+++ b/apps/web/src/app/licitacoes/[id]/perguntas/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Layout } from "@/components/layout";
+import { Button } from "@/components/ui/button";
+import { PerguntasTab } from "@/components/perguntas/PerguntasTab";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function PerguntasPage({ params }: PageProps) {
+  const { id } = await params;
+
+  return (
+    <Layout>
+      <div className="mx-auto">
+        <div className="mb-8">
+          <Link href={`/licitacoes/${id}`}>
+            <Button
+              variant="ghost"
+              className="pl-0 text-slate-500 hover:text-slate-900 hover:bg-transparent mb-4"
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Voltar para licitação
+            </Button>
+          </Link>
+          <h1 className="text-2xl md:text-3xl font-heading font-bold text-slate-900 mb-2">
+            Chat com o Edital
+          </h1>
+          <p className="text-slate-600">
+            Faça perguntas sobre o edital analisado pela IA
+          </p>
+        </div>
+
+        <PerguntasTab bidId={id} />
+      </div>
+    </Layout>
+  );
+}

--- a/apps/web/src/components/perguntas/PerguntasTab.tsx
+++ b/apps/web/src/components/perguntas/PerguntasTab.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { FileX, Send } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/hooks/use-toast";
+import { chatComEdital, getChatHistorico, type ChatMensagem } from "@/lib/api";
+
+interface PerguntasTabProps {
+  bidId: string;
+}
+
+interface PerguntaRapida {
+  label: string;
+  pergunta: string;
+}
+
+const PERGUNTAS_RAPIDAS: PerguntaRapida[] = [
+  {
+    label: "Qual o objeto?",
+    pergunta:
+      "Qual é o objeto desta licitação? Descreva de forma resumida o que está sendo contratado.",
+  },
+  {
+    label: "Quando é a abertura?",
+    pergunta:
+      "Qual é a data e horário de abertura da sessão pública desta licitação?",
+  },
+  {
+    label: "Quais os pré-requisitos?",
+    pergunta:
+      "Quais são os pré-requisitos e requisitos de habilitação exigidos para participar desta licitação?",
+  },
+  {
+    label: "Documentação necessária?",
+    pergunta:
+      "Quais documentos são necessários para a habilitação nesta licitação?",
+  },
+  {
+    label: "Valor estimado?",
+    pergunta: "Qual é o valor estimado ou referência desta licitação?",
+  },
+  {
+    label: "ME/EPP têm preferência?",
+    pergunta:
+      "Há benefícios ou preferências para microempresas (ME) e empresas de pequeno porte (EPP) nesta licitação?",
+  },
+  {
+    label: "Prazo do contrato?",
+    pergunta: "Qual é o prazo de vigência do contrato a ser firmado?",
+  },
+  {
+    label: "Exige garantia?",
+    pergunta:
+      "Há exigência de garantia de proposta ou de execução contratual? Se sim, qual o percentual e modalidades aceitas?",
+  },
+  {
+    label: "Sanções previstas?",
+    pergunta:
+      "Quais são as sanções e penalidades previstas em caso de descumprimento contratual?",
+  },
+];
+
+export function PerguntasTab({ bidId }: PerguntasTabProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [historico, setHistorico] = useState<ChatMensagem[]>([]);
+  const [pergunta, setPergunta] = useState("");
+  const [isLoadingHistorico, setIsLoadingHistorico] = useState(true);
+  const [isRespondendo, setIsRespondendo] = useState(false);
+  const [semAnalise, setSemAnalise] = useState(false);
+
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    const carregarHistorico = async () => {
+      setIsLoadingHistorico(true);
+      try {
+        const data = await getChatHistorico(bidId);
+        setHistorico(data);
+      } catch (error: any) {
+        const apiMessage = error?.response?.data?.message;
+        if (apiMessage === "ANALISE_NAO_ENCONTRADA") {
+          setSemAnalise(true);
+          return;
+        }
+
+        toast({
+          title: "Erro ao carregar histórico",
+          description:
+            apiMessage ||
+            "Não foi possível carregar as mensagens do chat neste momento.",
+          variant: "destructive",
+        });
+      } finally {
+        setIsLoadingHistorico(false);
+      }
+    };
+
+    void carregarHistorico();
+  }, [bidId, toast]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [historico, isRespondendo, semAnalise]);
+
+  const ajustarAlturaTextarea = () => {
+    if (!textareaRef.current) return;
+    textareaRef.current.style.height = "auto";
+    textareaRef.current.style.height = `${Math.min(
+      textareaRef.current.scrollHeight,
+      120,
+    )}px`;
+  };
+
+  const handleEnviarPergunta = async (textoPergunta?: string) => {
+    const perguntaFinal = (textoPergunta ?? pergunta).trim();
+    if (perguntaFinal.length < 3 || isRespondendo || semAnalise) {
+      return;
+    }
+
+    setIsRespondendo(true);
+    try {
+      // Delay mínimo para exibir animação de "pensando" sem atrasar respostas lentas.
+      const [respostaReal] = await Promise.all([
+        chatComEdital(bidId, perguntaFinal),
+        new Promise((resolve) => setTimeout(resolve, 1500)),
+      ]);
+
+      setHistorico((prev) => [
+        ...prev,
+        {
+          id: `temp-${Date.now()}`,
+          pergunta: respostaReal.pergunta,
+          resposta: respostaReal.resposta,
+          createdAt: respostaReal.createdAt,
+        },
+      ]);
+      setPergunta("");
+      if (textareaRef.current) {
+        textareaRef.current.style.height = "44px";
+      }
+    } catch (error: any) {
+      const apiMessage = error?.response?.data?.message;
+      if (apiMessage === "ANALISE_NAO_ENCONTRADA") {
+        setSemAnalise(true);
+        return;
+      }
+
+      toast({
+        title: "Erro ao perguntar",
+        description:
+          apiMessage ||
+          "Não foi possível processar sua pergunta agora. Tente novamente.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsRespondendo(false);
+    }
+  };
+
+  const handlePerguntaRapida = async (item: PerguntaRapida) => {
+    setPergunta(item.pergunta);
+    await handleEnviarPergunta(item.pergunta);
+  };
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-120px)] border border-border rounded-2xl overflow-hidden bg-background">
+      <div className="flex items-center gap-3 p-4 border-b border-border">
+        <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center text-white text-sm font-bold">
+          L
+        </div>
+        <div>
+          <p className="font-semibold text-sm">LicitaIA</p>
+          <p className="text-xs text-muted-foreground">
+            Assistente especializado em editais
+          </p>
+        </div>
+        <div className="ml-auto flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-green-500"></div>
+          <span className="text-xs text-muted-foreground">Online</span>
+        </div>
+      </div>
+
+      <div className="flex gap-2 p-3 border-b border-border overflow-x-auto">
+        {PERGUNTAS_RAPIDAS.map((item) => (
+          <button
+            key={item.label}
+            onClick={() => void handlePerguntaRapida(item)}
+            disabled={isRespondendo || semAnalise}
+            className="text-xs px-3 py-1.5 rounded-full border border-border hover:bg-accent hover:border-primary transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4">
+        {semAnalise ? (
+          <div className="h-full flex flex-col items-center justify-center gap-4 text-center p-8">
+            <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+              <FileX className="w-8 h-8 text-muted-foreground" />
+            </div>
+            <div>
+              <p className="font-semibold">Edital não analisado</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Para usar o LicitaIA, primeiro analise o edital desta licitação.
+              </p>
+            </div>
+            <button
+              onClick={() => router.push(`/licitacoes/${bidId}`)}
+              className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 transition-colors"
+            >
+              Ir para análise do edital
+            </button>
+          </div>
+        ) : (
+          <>
+            {isLoadingHistorico ? (
+              <p className="text-sm text-muted-foreground">
+                Carregando mensagens...
+              </p>
+            ) : historico.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Faça uma pergunta para começar a conversa com o LicitaIA.
+              </p>
+            ) : (
+              historico.map((mensagem) => (
+                <div key={mensagem.id}>
+                  <div className="flex justify-end mb-4">
+                    <div className="max-w-[75%]">
+                      <div className="bg-blue-600 text-white px-4 py-3 rounded-2xl rounded-tr-sm text-sm leading-relaxed whitespace-pre-wrap">
+                        {mensagem.pergunta}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1 text-right">
+                        Você
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="flex gap-3 mb-4">
+                    <div className="w-7 h-7 rounded-full bg-blue-600 flex items-center justify-center text-white text-xs font-bold flex-shrink-0 mt-1">
+                      L
+                    </div>
+                    <div className="max-w-[75%]">
+                      <p className="text-xs text-muted-foreground mb-1">
+                        LicitaIA
+                      </p>
+                      <div className="bg-muted px-4 py-3 rounded-2xl rounded-tl-sm text-sm leading-relaxed whitespace-pre-wrap">
+                        {mensagem.resposta}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1 italic">
+                        ⚠️ Baseado na análise automática. Confirme no documento
+                        original.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+
+            {isRespondendo && (
+              <div className="flex gap-3 mb-4">
+                <div className="w-7 h-7 rounded-full bg-blue-600 flex items-center justify-center text-white text-xs font-bold flex-shrink-0 mt-1">
+                  L
+                </div>
+                <div className="bg-muted px-4 py-3 rounded-2xl rounded-tl-sm">
+                  <div className="flex items-center gap-1">
+                    <div
+                      className="w-2 h-2 bg-muted-foreground rounded-full animate-bounce"
+                      style={{ animationDelay: "0ms" }}
+                    ></div>
+                    <div
+                      className="w-2 h-2 bg-muted-foreground rounded-full animate-bounce"
+                      style={{ animationDelay: "150ms" }}
+                    ></div>
+                    <div
+                      className="w-2 h-2 bg-muted-foreground rounded-full animate-bounce"
+                      style={{ animationDelay: "300ms" }}
+                    ></div>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    LicitaIA está pensando...
+                  </p>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="border-t border-border p-4">
+        <div className="flex gap-2 items-end">
+          <textarea
+            ref={textareaRef}
+            value={pergunta}
+            onChange={(event) => {
+              setPergunta(event.target.value);
+              ajustarAlturaTextarea();
+            }}
+            disabled={isRespondendo || semAnalise}
+            className="flex-1 resize-none bg-muted rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[44px] max-h-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
+            placeholder="Pergunte sobre o edital..."
+            rows={1}
+          />
+          <button
+            onClick={() => void handleEnviarPergunta()}
+            disabled={isRespondendo || semAnalise || pergunta.trim().length < 3}
+            className="bg-blue-600 hover:bg-blue-700 text-white rounded-xl px-4 py-3 text-sm font-medium transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Send className="w-4 h-4" />
+          </button>
+        </div>
+        <p className="text-xs text-muted-foreground mt-2 text-center">
+          LicitaIA pode cometer erros. Sempre verifique o edital original.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -208,6 +208,30 @@ export async function getHistoricoSimulacoes(bidId: string): Promise<SimulacaoDi
   return data;
 }
 
+// --- Chat com Edital ---
+export interface ChatResposta {
+  resposta: string;
+  pergunta: string;
+  createdAt: string;
+}
+
+export interface ChatMensagem {
+  id: string;
+  pergunta: string;
+  resposta: string;
+  createdAt: string;
+}
+
+export async function chatComEdital(bidId: string, pergunta: string): Promise<ChatResposta> {
+  const { data } = await api.post(`/bids/${bidId}/chat`, { pergunta });
+  return data;
+}
+
+export async function getChatHistorico(bidId: string): Promise<ChatMensagem[]> {
+  const { data } = await api.get(`/bids/${bidId}/chat/historico`);
+  return data;
+}
+
 // --- Análise de Mercado (PNCP) ---
 export interface HistoricoCompraItem {
   data: string;


### PR DESCRIPTION
- Endpoint POST /bids/:id/chat com prompt contextualizado e anti-alucinação
- Endpoint GET /bids/:id/chat/historico (últimas 50 mensagens)
- Model ChatHistorico com tenant isolation e índice composto
- 9 perguntas rápidas pré-definidas como chips horizontais
- Animação 'pensando' com delay mínimo de 1.5s
- Interface estilo ChatGPT com identidade LicitaIA
- Aviso de IA visível em itálico após cada resposta
- Estado vazio elegante para licitação sem análise concluída
- Card Perguntas adicionado na tela central da licitação
- Histórico persiste e carrega com scroll automático para o final

Made-with: Cursor

## Descricao
<!-- Resuma as mudancas deste PR -->

## Issue Relacionada
<!-- Closes #1 -->

## Tipo de Mudanca
- [ ] Bug fix
- [ ] Nova feature
- [ ] Breaking change
- [ ] Documentacao
- [ ] Refactor
- [ ] Tests
- [ ] Chore

## Como Testar
1.
2.
3.

## Checklist
- [ ] Codigo segue padroes do projeto
- [ ] Self-review realizado
- [ ] Documentacao atualizada (se aplicavel)
- [ ] Sem novos warnings
- [ ] `pnpm typecheck` ok (se existir)
- [ ] `pnpm lint` ok (se existir)
- [ ] `pnpm build` ok (se existir)
