### PR TITLE
feat(users): add company user management guardrails

### DIFF
--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -9,6 +9,8 @@ import { PrismaTenantService } from "../prisma/prisma-tenant.service";
 import { type CreateUserInput, type User, UserRole } from "@licitafacil/shared";
 import * as bcrypt from "bcrypt";
 
+const MAX_USERS_PER_EMPRESA = 30;
+
 @Injectable()
 export class UserService {
   constructor(
@@ -138,6 +140,16 @@ export class UserService {
     empresaId: string,
     data: { email: string; password: string; name: string; role?: string },
   ): Promise<User> {
+    const totalUsuariosCriados = await this.prisma.user.count({
+      where: { empresaId },
+    });
+
+    if (totalUsuariosCriados >= MAX_USERS_PER_EMPRESA) {
+      throw new ForbiddenException(
+        `Limite de ${MAX_USERS_PER_EMPRESA} usuários atingido para esta empresa`,
+      );
+    }
+
     // Verificar se email já existe
     const existingUser = await this.prisma.user.findUnique({
       where: { email: data.email },
@@ -291,18 +303,23 @@ export class UserService {
 
   /**
    * Retorna informações de uso de usuários da empresa.
-   * Plano único high-ticket — sem restrições de limite.
+   * Limite fixo de 30 usuários por empresa.
    */
   async obterLimite(empresaId: string) {
-    const usuariosAtivos = await this.prisma.user.count({
-      where: { empresaId, deletedAt: null },
+    const usuariosCriados = await this.prisma.user.count({
+      where: { empresaId },
     });
 
+    const percentual = Math.min(
+      Math.round((usuariosCriados / MAX_USERS_PER_EMPRESA) * 100),
+      100,
+    );
+
     return {
-      atual: usuariosAtivos,
-      limite: 999999,
-      disponivel: 999999,
-      percentual: 0,
+      atual: usuariosCriados,
+      limite: MAX_USERS_PER_EMPRESA,
+      disponivel: Math.max(MAX_USERS_PER_EMPRESA - usuariosCriados, 0),
+      percentual,
     };
   }
 

--- a/apps/web/src/app/usuarios/page.tsx
+++ b/apps/web/src/app/usuarios/page.tsx
@@ -22,13 +22,12 @@ import { EditarUsuarioModal } from "@/components/usuarios/editar-usuario-modal";
 import { Layout } from "@/components/layout";
 import { useAuth } from "@/contexts/auth-context";
 import { api } from "@/lib/api";
+import { Progress } from "@/components/ui/progress";
 import { toast } from "@/hooks/use-toast";
 import {
   Users,
   Search,
   Edit,
-  UserX,
-  UserCheck,
   Trash2,
 } from "lucide-react";
 
@@ -41,6 +40,13 @@ interface Usuario {
   createdAt: string;
   updatedAt: string;
   ativo: boolean;
+}
+
+interface LimiteUsuarios {
+  atual: number;
+  limite: number;
+  disponivel: number;
+  percentual: number;
 }
 
 const roleLabel: Record<string, string> = {
@@ -60,6 +66,7 @@ export default function UsuariosPage() {
   const [usuarios, setUsuarios] = useState<Usuario[]>([]);
   const [busca, setBusca] = useState("");
   const [loading, setLoading] = useState(true);
+  const [limiteUsuarios, setLimiteUsuarios] = useState<LimiteUsuarios | null>(null);
   const [usuarioEditando, setUsuarioEditando] = useState<Usuario | null>(
     null,
   );
@@ -67,11 +74,13 @@ export default function UsuariosPage() {
   const carregarDados = useCallback(async () => {
     setLoading(true);
     try {
-      const [usuariosRes] = await Promise.all([
+      const [usuariosRes, limiteRes] = await Promise.all([
         api.get("/users"),
+        api.get("/users/limite"),
       ]);
 
       setUsuarios(usuariosRes.data);
+      setLimiteUsuarios(limiteRes.data);
     } catch (error: any) {
       console.error("Erro ao carregar usuários:", error);
       toast({
@@ -89,32 +98,6 @@ export default function UsuariosPage() {
       carregarDados();
     }
   }, [carregarDados, user, authLoading]);
-
-  async function toggleAtivo(usuario: Usuario) {
-    try {
-      if (usuario.ativo) {
-        await api.delete(`/users/${usuario.id}`);
-        toast({
-          title: "Usuário desativado",
-          description: `${usuario.name} foi desativado.`,
-        });
-      } else {
-        await api.post(`/users/${usuario.id}/reativar`);
-        toast({
-          title: "Usuário reativado",
-          description: `${usuario.name} foi reativado.`,
-        });
-      }
-      carregarDados();
-    } catch (error: any) {
-      toast({
-        title: "Erro",
-        description:
-          error.response?.data?.message || "Erro ao atualizar usuário.",
-        variant: "destructive",
-      });
-    }
-  }
 
   async function deletarPermanente(usuario: Usuario) {
     const confirma = window.confirm(
@@ -146,6 +129,10 @@ export default function UsuariosPage() {
   );
 
   const isAdmin = user?.role === "ADMIN" || user?.role === "SUPER_ADMIN";
+  const limite = limiteUsuarios?.limite ?? 30;
+  const totalUsuariosCriados = limiteUsuarios?.atual ?? usuarios.length;
+  const percentualUso = limiteUsuarios?.percentual ?? Math.min(Math.round((totalUsuariosCriados / limite) * 100), 100);
+  const limiteAtingido = totalUsuariosCriados >= limite;
 
 
   if (authLoading || !user) {
@@ -187,10 +174,29 @@ export default function UsuariosPage() {
           {isAdmin && (
             <CriarUsuarioModal
               onSuccess={carregarDados}
-              limiteAtingido={false}
+              limiteAtingido={limiteAtingido}
             />
           )}
         </div>
+
+        <Card>
+          <CardContent className="pt-6 space-y-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium text-gray-900 dark:text-gray-100">
+                Uso de usuários
+              </span>
+              <span className="text-muted-foreground">
+                {totalUsuariosCriados} de {limite}
+              </span>
+            </div>
+            <Progress value={totalUsuariosCriados} max={limite} />
+            <p className="text-xs text-muted-foreground">
+              {limiteAtingido
+                ? "Limite de 30 usuários atingido. Para aumentar, será necessário ajuste personalizado."
+                : `${percentualUso}% do limite utilizado.`}
+            </p>
+          </CardContent>
+        </Card>
 
         {/* Busca + Tabela */}
         <Card>
@@ -273,36 +279,21 @@ export default function UsuariosPage() {
                             >
                               <Edit className="h-4 w-4" />
                             </Button>
-                            {usuario.id !== user?.id && (
-                              <>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => toggleAtivo(usuario)}
-                                  disabled={false}
-                                  title={
-                                    usuario.ativo
-                                      ? "Desativar"
-                                      : "Reativar"
-                                  }
-                                >
-                                  {usuario.ativo ? (
-                                    <UserX className="h-4 w-4 text-red-500" />
-                                  ) : (
-                                    <UserCheck className="h-4 w-4 text-green-500" />
-                                  )}
-                                </Button>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => deletarPermanente(usuario)}
-                                  className="hover:bg-red-50 dark:hover:bg-red-950/50"
-                                  title="Excluir permanentemente (irreversível)"
-                                >
-                                  <Trash2 className="h-4 w-4 text-red-400" />
-                                </Button>
-                              </>
-                            )}
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => deletarPermanente(usuario)}
+                              disabled={usuario.id === user?.id}
+                              className="hover:bg-red-50 dark:hover:bg-red-950/50 text-red-600 dark:text-red-400 disabled:opacity-50"
+                              title={
+                                usuario.id === user?.id
+                                  ? "Você não pode remover sua própria conta"
+                                  : "Remover permanentemente (irreversível)"
+                              }
+                            >
+                              <Trash2 className="h-4 w-4 mr-1" />
+                              Remover
+                            </Button>
                           </div>
                         </TableCell>
                       )}

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -10,7 +10,7 @@ import {
     Newspaper, Building2, Search as SearchIcon, Zap,
     FileQuestion, Flag, Repeat, BookOpen,
     TrendingUp, History, Tag as TagIcon,
-    Target, CalendarDays,
+    Target, CalendarDays, Users,
 } from "lucide-react";
 import { AlertsDropdown } from "@/components/AlertsDropdown";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -170,6 +170,8 @@ function NavLink({ item, pathname }: { item: NavItem; pathname: string }) {
 
 /* ─── Mobile sidebar content ─────────────────────────────── */
 function MobileSidebarContent({ pathname, user, logout }: { pathname: string; user: any; logout: () => void }) {
+    const isEmpresaAdmin = user?.role === "ADMIN" || user?.role === "SUPER_ADMIN";
+
     return (
         <div className="flex flex-col h-full bg-white dark:bg-gray-900">
             <div className="px-4 py-4 border-b border-gray-100 dark:border-gray-800">
@@ -220,6 +222,16 @@ function MobileSidebarContent({ pathname, user, logout }: { pathname: string; us
                         })}
                     </div>
                 ))}
+                {isEmpresaAdmin && (
+                    <div className="mb-3">
+                        <p className="section-label px-2 mb-1">Equipe</p>
+                        <Link href="/usuarios"
+                            className="flex items-center gap-2.5 px-3 py-2 rounded-xl text-[13px] font-medium text-gray-600 dark:text-gray-400 hover:bg-blue-50 dark:hover:bg-blue-950 hover:text-blue-700 dark:hover:text-blue-300">
+                            <Users className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+                            Usuários
+                        </Link>
+                    </div>
+                )}
                 {user?.role === "SUPER_ADMIN" && (
                     <div className="mb-3">
                         <p className="section-label px-2 mb-1 text-amber-600">Admin</p>
@@ -249,6 +261,7 @@ export function Layout({ children, fullWidth = false }: {
     const pathname = usePathname();
     const [isMobileOpen, setIsMobileOpen] = useState(false);
     const { user, logout } = useAuth();
+    const isEmpresaAdmin = user?.role === "ADMIN" || user?.role === "SUPER_ADMIN";
 
     /* Flatten all groups into topbar-ready structure */
     const principalItems = navGroups.find(g => g.group === "Principal")?.items ?? [];
@@ -299,6 +312,13 @@ export function Layout({ children, fullWidth = false }: {
                             ? <NavDropdown key={item.label} item={item} pathname={pathname} />
                             : <NavLink key={item.href} item={item} pathname={pathname} />
                     ))}
+
+                    {isEmpresaAdmin && (
+                        <NavLink
+                            item={{ label: "Usuários", icon: Users, href: "/usuarios" }}
+                            pathname={pathname}
+                        />
+                    )}
 
                     {/* Admin */}
                     {user?.role === "SUPER_ADMIN" && (

--- a/apps/web/src/components/usuarios/criar-usuario-modal.tsx
+++ b/apps/web/src/components/usuarios/criar-usuario-modal.tsx
@@ -29,6 +29,7 @@ interface CriarUsuarioModalProps {
 
 export function CriarUsuarioModal({
   onSuccess,
+  limiteAtingido = false,
 }: CriarUsuarioModalProps) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -50,6 +51,16 @@ export function CriarUsuarioModal({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+
+    if (limiteAtingido) {
+      toast({
+        title: "Limite atingido",
+        description: "Sua empresa atingiu o limite de 30 usuários.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -79,7 +90,7 @@ export function CriarUsuarioModal({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
+        <Button disabled={limiteAtingido} title={limiteAtingido ? "Limite de 30 usuários atingido" : "Criar novo usuário"}>
           <UserPlus className="mr-2 h-4 w-4" />
           Novo Usuário
         </Button>


### PR DESCRIPTION
Expose the users area for company admins, enforce a fixed limit of 30 created users per company, and simplify actions to edit or permanently remove users with clear UI feedback.

Made-with: Cursor

## Descricao
<!-- Resuma as mudancas deste PR -->

## Issue Relacionada
<!-- Closes #1 -->

## Tipo de Mudanca
- [ ] Bug fix
- [ ] Nova feature
- [ ] Breaking change
- [ ] Documentacao
- [ ] Refactor
- [ ] Tests
- [ ] Chore

## Como Testar
1.
2.
3.

## Checklist
- [ ] Codigo segue padroes do projeto
- [ ] Self-review realizado
- [ ] Documentacao atualizada (se aplicavel)
- [ ] Sem novos warnings
- [ ] `pnpm typecheck` ok (se existir)
- [ ] `pnpm lint` ok (se existir)
- [ ] `pnpm build` ok (se existir)
