### PR TITLE
feat(F25-06): histórico de disputas com análise pós-sessão

### DIFF
--- a/apps/api/src/disputa/disputa.controller.ts
+++ b/apps/api/src/disputa/disputa.controller.ts
@@ -1,9 +1,23 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Request, UseGuards } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Request,
+  Res,
+  UseGuards,
+} from "@nestjs/common";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { Tenant } from "../common/decorators/tenant.decorator";
 import { CreateDisputaDto } from "./dto/create-disputa.dto";
 import { UpdateDisputaDto } from "./dto/update-disputa.dto";
 import { DisputaService } from "./disputa.service";
+import { GetHistoricoDisputaQueryDto } from "./dto/historico-disputa.dto";
+import type { Response } from "express";
 
 @UseGuards(JwtAuthGuard)
 @Controller("disputa")
@@ -18,6 +32,44 @@ export class DisputaController {
   @Get()
   async listarDisputas(@Tenant() empresaId: string) {
     return this.disputaService.listarDisputas(empresaId);
+  }
+
+  /**
+   * Histórico de disputas encerradas 
+   * GET /disputa/historico
+   */
+  @Get("historico")
+  async listarHistorico(
+    @Tenant() empresaId: string,
+    @Query() query: GetHistoricoDisputaQueryDto,
+  ) {
+    return this.disputaService.listarHistorico(empresaId, query);
+  }
+
+  /**
+   * Detalhes de uma disputa encerrada 
+   * GET /disputa/historico/:id
+   */
+  @Get("historico/:id")
+  async detalheHistorico(@Param("id") id: string, @Tenant() empresaId: string) {
+    return this.disputaService.buscarHistoricoDetalhe(id, empresaId);
+  }
+
+  /**
+   * Exporta PDF do histórico da disputa 
+   * GET /disputa/historico/:id/pdf
+   */
+  @Get("historico/:id/pdf")
+  async exportarHistoricoPdf(
+    @Param("id") id: string,
+    @Tenant() empresaId: string,
+    @Res() res: Response,
+  ) {
+    const { buffer, fileName } = await this.disputaService.gerarHistoricoPdf(id, empresaId);
+
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `attachment; filename=\"${fileName}\"`);
+    res.send(buffer);
   }
 
   @Get(":id")

--- a/apps/api/src/disputa/disputa.service.ts
+++ b/apps/api/src/disputa/disputa.service.ts
@@ -13,6 +13,7 @@ import { CreateDisputaDto } from "./dto/create-disputa.dto";
 import { UpdateDisputaDto } from "./dto/update-disputa.dto";
 import { DisputaEventoPayload } from "./interfaces/disputa-evento.interface";
 import { DisputaGateway } from "./disputa.gateway";
+import { GetHistoricoDisputaQueryDto } from "./dto/historico-disputa.dto";
 
 type DisputaCompleta = Prisma.DisputaGetPayload<{
   include: {
@@ -275,6 +276,211 @@ export class DisputaService {
     return { ok: true };
   }
 
+  /**
+   * Histórico de disputas encerradas com filtros e paginação (F25-06)
+   */
+  async listarHistorico(empresaId: string, query: GetHistoricoDisputaQueryDto) {
+    const page = query.page && query.page > 0 ? query.page : 1;
+    const limit = query.limit && query.limit > 0 && query.limit <= 100 ? query.limit : 10;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.DisputaWhereInput = {
+      empresaId,
+      status: { in: [DisputaStatus.ENCERRADA, DisputaStatus.CANCELADA] },
+    };
+
+    if (query.portal) {
+      where.portal = query.portal;
+    }
+
+    if (query.dataInicio || query.dataFim) {
+      where.iniciadoEm = {};
+      if (query.dataInicio) {
+        (where.iniciadoEm as Prisma.DateTimeFilter).gte = new Date(query.dataInicio);
+      }
+      if (query.dataFim) {
+        const fim = new Date(query.dataFim);
+        // incluir o dia inteiro
+        fim.setHours(23, 59, 59, 999);
+        (where.iniciadoEm as Prisma.DateTimeFilter).lte = fim;
+      }
+    }
+
+    if (query.licitacao) {
+      where.bid = {
+        OR: [
+          { title: { contains: query.licitacao, mode: "insensitive" } },
+          { agency: { contains: query.licitacao, mode: "insensitive" } },
+        ],
+      };
+    }
+
+    const [total, disputas] = await Promise.all([
+      this.prisma.disputa.count({ where }),
+      this.prisma.disputa.findMany({
+        where,
+        include: {
+          bid: true,
+          configuracoes: true,
+          historico: true,
+        },
+        orderBy: { iniciadoEm: "desc" },
+        skip,
+        take: limit,
+      }),
+    ]);
+
+    const itens = disputas.map((disputa) => {
+      const resumo = this.calcularMetricasHistorico(disputa);
+      let resultado: "GANHOU" | "PERDEU" | "CANCELOU";
+      if (disputa.status === DisputaStatus.CANCELADA) {
+        resultado = "CANCELOU";
+      } else if (resumo.economiaTotal > 0) {
+        resultado = "GANHOU";
+      } else {
+        resultado = "PERDEU";
+      }
+      return {
+        id: disputa.id,
+        portal: disputa.portal,
+        status: disputa.status,
+        resultado,
+        iniciadoEm: disputa.iniciadoEm,
+        encerradoEm: disputa.encerradoEm,
+        bid: disputa.bid
+          ? {
+              id: disputa.bid.id,
+              title: disputa.bid.title,
+              agency: disputa.bid.agency,
+            }
+          : null,
+        economia: resumo.economiaTotal,
+        valorMaximoTotal: resumo.valorMaximoTotal,
+        melhorLanceGlobal: resumo.melhorLanceGlobal,
+      };
+    });
+
+    // filtro por resultado (aplicado após cálculo de economia/resultado)
+    let data = itens;
+    if (query.resultado === "GANHOU") {
+      data = itens.filter((i) => i.resultado === "GANHOU");
+    } else if (query.resultado === "PERDEU") {
+      data = itens.filter((i) => i.resultado === "PERDEU");
+    } else if (query.resultado === "CANCELOU") {
+      data = itens.filter((i) => i.resultado === "CANCELOU");
+    }
+
+    return {
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+    };
+  }
+
+  /**
+   * Detalhes de histórico de uma disputa encerrada (F25-06)
+   */
+  async buscarHistoricoDetalhe(id: string, empresaId: string) {
+    const disputa = await this.prisma.disputa.findFirst({
+      where: { id, empresaId, status: DisputaStatus.ENCERRADA },
+      include: {
+        bid: true,
+        configuracoes: true,
+        historico: true,
+      },
+    });
+
+    if (!disputa) {
+      throw new NotFoundException("Disputa encerrada não encontrada");
+    }
+
+    const metricas = this.calcularMetricasHistorico(disputa);
+
+    const timeline = disputa.historico
+      .slice()
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
+      .map((h) => ({
+        id: h.id,
+        itemNumero: h.itemNumero,
+        valorEnviado: h.valorEnviado ? Number(h.valorEnviado) : null,
+        melhorLance: h.melhorLance ? Number(h.melhorLance) : null,
+        posicao: h.posicao,
+        evento: h.evento,
+        detalhe: h.detalhe,
+        timestamp: h.timestamp.toISOString(),
+      }));
+
+    return {
+      disputa: {
+        id: disputa.id,
+        portal: disputa.portal,
+        status: disputa.status,
+        iniciadoEm: disputa.iniciadoEm,
+        encerradoEm: disputa.encerradoEm,
+        bid: disputa.bid
+          ? {
+              id: disputa.bid.id,
+              title: disputa.bid.title,
+              agency: disputa.bid.agency,
+            }
+          : null,
+      },
+      metricas,
+      timeline,
+    };
+  }
+
+  /**
+   * Gera PDF do histórico de disputa usando HTML simples (F25-06).
+   */
+  async gerarHistoricoPdf(id: string, empresaId: string) {
+    const detalhe = await this.buscarHistoricoDetalhe(id, empresaId);
+
+    const titulo = detalhe.disputa.bid?.title ?? "Disputa";
+    const nomeArquivoBase = titulo
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gi, "_")
+      .replace(/^_+|_+$/g, "")
+      .slice(0, 60);
+    const fileName = `${nomeArquivoBase || "disputa"}_historico.pdf`;
+
+    const html = this.montarHtmlHistorico(detalhe);
+
+    // Importação lazy do puppeteer-core para evitar custo em testes
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const puppeteer = require("puppeteer-core") as typeof import("puppeteer-core");
+    const browser = await puppeteer.launch({
+      executablePath: process.env.CHROMIUM_PATH || "/usr/bin/chromium",
+      args: [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-gpu",
+        "--no-first-run",
+        "--no-zygote",
+        "--single-process",
+      ],
+      headless: true,
+    });
+
+    try {
+      const page = await browser.newPage();
+      await page.setContent(html, { waitUntil: "networkidle0" });
+      const pdf = await page.pdf({
+        format: "A4",
+        margin: { top: "20mm", right: "15mm", bottom: "20mm", left: "15mm" },
+        printBackground: true,
+      });
+      return { buffer: Buffer.from(pdf), fileName };
+    } finally {
+      await browser.close();
+    }
+  }
+
   async emitirEvento(disputaId: string, evento: EventoDisputa, payload: DisputaEventoPayload) {
     const historico = await this.prisma.historicoLance.create({
       data: {
@@ -320,6 +526,246 @@ export class DisputaService {
     }
 
     return disputa;
+  }
+
+  /**
+   * Calcula métricas agregadas da disputa a partir das configurações e do histórico.
+   */
+  private calcularMetricasHistorico(disputa: {
+    configuracoes: { itemNumero: number; valorMaximo: Prisma.Decimal; ativo: boolean }[];
+    historico: {
+      itemNumero: number;
+      melhorLance: Prisma.Decimal | null;
+      valorEnviado: Prisma.Decimal | null;
+      evento: EventoDisputa;
+    }[];
+    iniciadoEm: Date | null;
+    encerradoEm: Date | null;
+  }) {
+    const ativos = disputa.configuracoes.filter((c) => c.ativo);
+    const valorMaximoTotal = ativos.reduce(
+      (acc, c) => acc + Number(c.valorMaximo),
+      0,
+    );
+
+    const melhorPorItem = new Map<number, number>();
+    let totalLancesEnviados = 0;
+    let nossoUltimoLance: number | null = null;
+
+    for (const h of disputa.historico) {
+      // rastrear melhor lance por item
+      if (h.melhorLance != null) {
+        const atual = melhorPorItem.get(h.itemNumero);
+        const valor = Number(h.melhorLance);
+        if (atual == null || valor < atual) {
+          melhorPorItem.set(h.itemNumero, valor);
+        }
+      }
+
+      // contar lances enviados por nós (inclui LANCE_ENVIADO e LANCE_MANUAL)
+      if (
+        h.valorEnviado != null &&
+        (h.evento === EventoDisputa.LANCE_ENVIADO || h.evento === EventoDisputa.LANCE_MANUAL)
+      ) {
+        totalLancesEnviados += 1;
+        nossoUltimoLance = Number(h.valorEnviado);
+      }
+    }
+
+    let economiaTotal = 0;
+    let melhorLanceGlobal: number | null = null;
+
+    for (const config of ativos) {
+      const max = Number(config.valorMaximo);
+      const melhor = melhorPorItem.get(config.itemNumero);
+      if (melhor != null) {
+        const economiaItem = Math.max(0, max - melhor);
+        economiaTotal += economiaItem;
+        if (melhorLanceGlobal == null || melhor < melhorLanceGlobal) {
+          melhorLanceGlobal = melhor;
+        }
+      }
+    }
+
+    let duracaoSegundos: number | null = null;
+    if (disputa.iniciadoEm && disputa.encerradoEm) {
+      duracaoSegundos = Math.max(
+        0,
+        Math.round((disputa.encerradoEm.getTime() - disputa.iniciadoEm.getTime()) / 1000),
+      );
+    }
+
+    return {
+      valorMaximoTotal,
+      economiaTotal,
+      melhorLanceGlobal,
+      duracaoSegundos,
+      totalLancesEnviados,
+      nossoUltimoLance,
+    };
+  }
+
+  /**
+   * Monta HTML simplificado para o relatório de histórico de disputa (F25-06).
+   */
+  private montarHtmlHistorico(detalhe: {
+    disputa: {
+      id: string;
+      portal: string;
+      status: DisputaStatus;
+      iniciadoEm: Date | string | null;
+      encerradoEm: Date | string | null;
+      bid: { id: string; title: string; agency: string } | null;
+    };
+    metricas: {
+      valorMaximoTotal: number;
+      economiaTotal: number;
+      melhorLanceGlobal: number | null;
+      duracaoSegundos: number | null;
+      totalLancesEnviados: number;
+      nossoUltimoLance: number | null;
+    };
+    timeline: Array<{
+      id: string;
+      itemNumero: number;
+      valorEnviado: number | null;
+      melhorLance: number | null;
+      posicao: number | null;
+      evento: EventoDisputa;
+      detalhe: string | null;
+      timestamp: string;
+    }>;
+  }): string {
+    const titulo = detalhe.disputa.bid?.title ?? "Disputa";
+    const agency = detalhe.disputa.bid?.agency ?? "-";
+
+    const dataInicio = detalhe.disputa.iniciadoEm
+      ? new Date(detalhe.disputa.iniciadoEm).toLocaleString("pt-BR")
+      : "-";
+    const dataFim = detalhe.disputa.encerradoEm
+      ? new Date(detalhe.disputa.encerradoEm).toLocaleString("pt-BR")
+      : "-";
+
+    const linhaTempo = detalhe.timeline
+      .map((e) => {
+        const ts = new Date(e.timestamp).toLocaleString("pt-BR");
+        const valor =
+          e.valorEnviado != null ? `R$ ${e.valorEnviado.toFixed(2)}` : "-";
+        const melhor =
+          e.melhorLance != null ? `R$ ${e.melhorLance.toFixed(2)}` : "-";
+        const posicao = e.posicao != null ? `#${e.posicao}` : "-";
+        return `
+        <tr>
+          <td>${ts}</td>
+          <td>${e.itemNumero}</td>
+          <td>${e.evento}</td>
+          <td>${valor}</td>
+          <td>${melhor}</td>
+          <td>${posicao}</td>
+          <td>${e.detalhe ?? ""}</td>
+        </tr>`;
+      })
+      .join("");
+
+    const duracao =
+      detalhe.metricas.duracaoSegundos != null
+        ? `${Math.floor(detalhe.metricas.duracaoSegundos / 60)} min`
+        : "-";
+
+    const nossoUltimo =
+      detalhe.metricas.nossoUltimoLance != null
+        ? `R$ ${detalhe.metricas.nossoUltimoLance.toFixed(2)}`
+        : "-";
+
+    return `<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size: 11px; color: #0f172a; margin: 0; padding: 24px; }
+      h1 { font-size: 20px; margin-bottom: 4px; }
+      h2 { font-size: 14px; margin: 16px 0 8px; }
+      .muted { color: #64748b; font-size: 10px; }
+      .header { margin-bottom: 16px; }
+      .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-top: 8px; }
+      .card { border: 1px solid #e2e8f0; border-radius: 6px; padding: 8px; background: #f8fafc; }
+      .card-label { font-size: 10px; color: #64748b; }
+      .card-value { font-size: 14px; font-weight: 600; margin-top: 2px; }
+      table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+      th, td { border: 1px solid #e2e8f0; padding: 4px 6px; text-align: left; }
+      th { background: #f1f5f9; font-size: 10px; }
+      td { font-size: 10px; }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h1>Histórico da Disputa</h1>
+      <div class="muted">
+        <div>${titulo}</div>
+        <div>${agency}</div>
+        <div>Portal: ${detalhe.disputa.portal} • Status: ${detalhe.disputa.status}</div>
+      </div>
+    </div>
+
+    <h2>Resumo</h2>
+    <div class="grid">
+      <div class="card">
+        <div class="card-label">Valor máximo total</div>
+        <div class="card-value">R$ ${detalhe.metricas.valorMaximoTotal.toFixed(2)}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Economia gerada</div>
+        <div class="card-value">R$ ${detalhe.metricas.economiaTotal.toFixed(2)}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Melhor lance global</div>
+        <div class="card-value">${
+          detalhe.metricas.melhorLanceGlobal != null
+            ? `R$ ${detalhe.metricas.melhorLanceGlobal.toFixed(2)}`
+            : "-"
+        }</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Início</div>
+        <div class="card-value">${dataInicio}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Término</div>
+        <div class="card-value">${dataFim}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Duração aproximada</div>
+        <div class="card-value">${duracao}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Total de lances enviados</div>
+        <div class="card-value">${detalhe.metricas.totalLancesEnviados}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Seu último lance</div>
+        <div class="card-value">${nossoUltimo}</div>
+      </div>
+    </div>
+
+    <h2>Linha do tempo de lances</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Data/Hora</th>
+          <th>Item</th>
+          <th>Evento</th>
+          <th>Valor enviado</th>
+          <th>Melhor lance</th>
+          <th>Posição</th>
+          <th>Detalhe</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${linhaTempo}
+      </tbody>
+    </table>
+  </body>
+</html>`;
   }
 
   async atualizarStatus(disputaId: string, status: DisputaStatus) {

--- a/apps/api/src/disputa/dto/historico-disputa.dto.ts
+++ b/apps/api/src/disputa/dto/historico-disputa.dto.ts
@@ -1,0 +1,36 @@
+import { PortalLicitacao } from "@prisma/client";
+import { IsEnum, IsInt, IsISO8601, IsOptional, IsString, Min, MinLength } from "class-validator";
+
+export class GetHistoricoDisputaQueryDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  limit?: number;
+
+  @IsOptional()
+  @IsEnum(PortalLicitacao)
+  portal?: PortalLicitacao;
+
+  @IsOptional()
+  @IsISO8601()
+  dataInicio?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  dataFim?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  licitacao?: string;
+
+  @IsOptional()
+  @IsString()
+  resultado?: "GANHOU" | "PERDEU" | "CANCELOU";
+}
+

--- a/apps/web/src/app/disputa/historico/[id]/page.tsx
+++ b/apps/web/src/app/disputa/historico/[id]/page.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Layout } from "@/components/layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import { api } from "@/lib/api";
+import { Download } from "lucide-react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+
+interface HistoricoDetalheResponse {
+  disputa: {
+    id: string;
+    portal: string;
+    status: string;
+    iniciadoEm: string | null;
+    encerradoEm: string | null;
+    bid: { id: string; title: string; agency: string } | null;
+  };
+  metricas: {
+    valorMaximoTotal: number;
+    economiaTotal: number;
+    melhorLanceGlobal: number | null;
+    duracaoSegundos: number | null;
+    totalLancesEnviados: number;
+    nossoUltimoLance: number | null;
+  };
+  timeline: Array<{
+    id: string;
+    itemNumero: number;
+    valorEnviado: number | null;
+    melhorLance: number | null;
+    posicao: number | null;
+    evento: string;
+    detalhe: string | null;
+    timestamp: string;
+  }>;
+}
+
+export default function DisputaHistoricoDetalhePage() {
+  const { id } = useParams<{ id: string }>();
+  const { toast } = useToast();
+  const [data, setData] = useState<HistoricoDetalheResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get<HistoricoDetalheResponse>(`/disputa/historico/${id}`);
+      setData(data);
+    } catch {
+      toast({ title: "Erro ao carregar detalhes da disputa", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (id) {
+      load();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const handleExportPdf = async () => {
+    try {
+      setDownloading(true);
+      const response = await api.get(`/disputa/historico/${id}/pdf`, {
+        responseType: "arraybuffer",
+      });
+      const blob = new Blob([response.data], { type: "application/pdf" });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      const header = response.headers["content-disposition"] as string | undefined;
+      const match = header?.match(/filename="([^"]+)"/);
+      const fileName = match?.[1] || "disputa_historico.pdf";
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch {
+      toast({ title: "Erro ao gerar PDF", variant: "destructive" });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  if (loading || !data) {
+    return (
+      <Layout>
+        <div className="mx-auto py-10 text-center text-slate-500 text-sm">
+          Carregando detalhes da disputa...
+        </div>
+      </Layout>
+    );
+  }
+
+  const { disputa, metricas, timeline } = data;
+
+  const duracaoMin =
+    metricas.duracaoSegundos != null ? Math.round(metricas.duracaoSegundos / 60) : null;
+
+  const chartData = timeline
+    .filter((e) => e.melhorLance != null)
+    .map((e) => ({
+      time: new Date(e.timestamp).toLocaleTimeString("pt-BR", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }),
+      melhorLance: e.melhorLance as number,
+    }));
+
+  return (
+    <Layout>
+      <div className="mx-auto space-y-6">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-2xl md:text-3xl font-heading font-bold text-slate-900">
+              Detalhes da Disputa
+            </h1>
+            <p className="text-slate-600 mt-1">
+              Histórico completo de lances e métricas da disputa.
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={handleExportPdf}
+            disabled={downloading}
+            className="bg-slate-900 hover:bg-slate-800 text-white"
+          >
+            <Download className="w-4 h-4 mr-2" />
+            Exportar PDF
+          </Button>
+        </div>
+
+        <Card className="border-slate-200">
+          <CardHeader>
+            <CardTitle className="text-lg font-heading">Resumo</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-3">
+            <div>
+              <p className="text-xs text-slate-500 mb-1">Licitação</p>
+              <p className="text-sm font-medium text-slate-900">
+                {disputa.bid?.title ?? "Disputa sem licitação vinculada"}
+              </p>
+              <p className="text-xs text-slate-500 mt-0.5">{disputa.bid?.agency ?? "-"}</p>
+            </div>
+            <div>
+              <p className="text-xs text-slate-500 mb-1">Portal / Status</p>
+              <p className="text-sm font-medium text-slate-900">
+                {disputa.portal} • {disputa.status}
+              </p>
+              <p className="text-xs text-slate-500 mt-0.5">
+                Início:{" "}
+                {disputa.iniciadoEm
+                  ? new Date(disputa.iniciadoEm).toLocaleString("pt-BR")
+                  : "-"}
+              </p>
+              <p className="text-xs text-slate-500">
+                Encerramento:{" "}
+                {disputa.encerradoEm
+                  ? new Date(disputa.encerradoEm).toLocaleString("pt-BR")
+                  : "-"}
+              </p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs text-slate-500 mb-1">Métricas</p>
+              <p className="text-sm text-slate-700">
+                Valor máximo total:{" "}
+                <span className="font-semibold">
+                  R$ {metricas.valorMaximoTotal.toFixed(2)}
+                </span>
+              </p>
+              <p className="text-sm text-slate-700">
+                Economia gerada:{" "}
+                <span className="font-semibold text-emerald-600">
+                  R$ {metricas.economiaTotal.toFixed(2)}
+                </span>
+              </p>
+              <p className="text-sm text-slate-700">
+                Lance vencedor (melhor lance):{" "}
+                <span className="font-semibold">
+                  {metricas.melhorLanceGlobal != null
+                    ? `R$ ${metricas.melhorLanceGlobal.toFixed(2)}`
+                    : "-"}
+                </span>
+              </p>
+              <p className="text-sm text-slate-700">
+                Seu lance final:{" "}
+                <span className="font-semibold">
+                  {metricas.nossoUltimoLance != null
+                    ? `R$ ${metricas.nossoUltimoLance.toFixed(2)}`
+                    : "-"}
+                </span>
+              </p>
+              <p className="text-sm text-slate-700">
+                Total de lances enviados:{" "}
+                <span className="font-semibold">{metricas.totalLancesEnviados}</span>
+              </p>
+              <p className="text-xs text-slate-500">
+                Duração aproximada: {duracaoMin != null ? `${duracaoMin} min` : "-"}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {chartData.length > 0 && (
+          <Card className="border-slate-200">
+            <CardHeader>
+              <CardTitle className="text-lg font-heading">
+                Evolução do melhor lance ao longo da sessão
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="h-64 w-full">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <XAxis
+                      dataKey="time"
+                      tick={{ fontSize: 10 }}
+                      tickMargin={8}
+                      stroke="#64748b"
+                    />
+                    <YAxis
+                      tickFormatter={(v: number) => `R$ ${v.toFixed(0)}`}
+                      stroke="#64748b"
+                      width={70}
+                    />
+                    <Tooltip
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      formatter={(value: any) =>
+                        typeof value === "number"
+                          ? [`R$ ${value.toFixed(2)}`, "Melhor lance"]
+                          : [String(value ?? ""), "Melhor lance"]
+                      }
+                      labelFormatter={(label) => `Horário: ${label}`}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="melhorLance"
+                      stroke="#0f172a"
+                      strokeWidth={2}
+                      dot={{ r: 2 }}
+                      activeDot={{ r: 4 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card className="border-slate-200">
+          <CardHeader>
+            <CardTitle className="text-lg font-heading">Linha do tempo de lances</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {timeline.length === 0 ? (
+              <p className="text-sm text-slate-500 py-4">
+                Nenhum evento registrado para esta disputa.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Data/Hora</TableHead>
+                      <TableHead>Item</TableHead>
+                      <TableHead>Evento</TableHead>
+                      <TableHead>Valor enviado</TableHead>
+                      <TableHead>Melhor lance</TableHead>
+                      <TableHead>Posição</TableHead>
+                      <TableHead>Detalhe</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {timeline.map((e) => (
+                      <TableRow key={e.id}>
+                        <TableCell>
+                          {new Date(e.timestamp).toLocaleString("pt-BR")}
+                        </TableCell>
+                        <TableCell>{e.itemNumero}</TableCell>
+                        <TableCell>{e.evento}</TableCell>
+                        <TableCell>
+                          {e.valorEnviado != null
+                            ? `R$ ${e.valorEnviado.toFixed(2)}`
+                            : "-"}
+                        </TableCell>
+                        <TableCell>
+                          {e.melhorLance != null
+                            ? `R$ ${e.melhorLance.toFixed(2)}`
+                            : "-"}
+                        </TableCell>
+                        <TableCell>{e.posicao != null ? `#${e.posicao}` : "-"}</TableCell>
+                        <TableCell>{e.detalhe ?? ""}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+}
+

--- a/apps/web/src/app/disputa/historico/page.tsx
+++ b/apps/web/src/app/disputa/historico/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Layout } from "@/components/layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/hooks/use-toast";
+import { api } from "@/lib/api";
+import { Search } from "lucide-react";
+
+interface HistoricoDisputaResumo {
+  id: string;
+  portal: string;
+  status: string;
+  resultado: string;
+  iniciadoEm: string | null;
+  encerradoEm: string | null;
+  bid: { id: string; title: string; agency: string } | null;
+  economia: number;
+  valorMaximoTotal: number;
+  melhorLanceGlobal: number | null;
+}
+
+interface HistoricoResponse {
+  data: HistoricoDisputaResumo[];
+  pagination: { page: number; limit: number; total: number; totalPages: number };
+}
+
+export default function DisputaHistoricoPage() {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [items, setItems] = useState<HistoricoDisputaResumo[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [licitacao, setLicitacao] = useState("");
+  const [portal, setPortal] = useState<string | undefined>();
+  const [resultado, setResultado] = useState<string | undefined>();
+  const [dataInicio, setDataInicio] = useState<string>("");
+  const [dataFim, setDataFim] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const params: Record<string, string | number | undefined> = {
+        page,
+        limit: 10,
+        licitacao: licitacao || undefined,
+        portal: portal || undefined,
+        resultado: resultado || undefined,
+        dataInicio: dataInicio || undefined,
+        dataFim: dataFim || undefined,
+      };
+      const { data } = await api.get<HistoricoResponse>("/disputa/historico", { params });
+      setItems(data.data);
+      setTotalPages(data.pagination.totalPages);
+    } catch {
+      toast({ title: "Erro ao carregar histórico de disputas", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, portal, resultado]);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setPage(1);
+    load();
+  };
+
+  return (
+    <Layout>
+      <div className="mx-auto">
+        <div className="mb-8 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h1 className="text-2xl md:text-3xl font-heading font-bold text-slate-900">
+              Histórico de Disputas
+            </h1>
+            <p className="text-slate-600 mt-1">
+              Consulte disputas encerradas, economia gerada e resultados por licitação.
+            </p>
+          </div>
+        </div>
+
+        <Card className="mb-6 border-slate-200">
+          <CardContent className="py-4 space-y-4">
+            <form onSubmit={handleSearch} className="flex flex-col md:flex-row gap-4">
+              <div className="flex-1 flex items-center gap-2">
+                <Search className="w-4 h-4 text-slate-400" />
+                <Input
+                  placeholder="Buscar por licitação ou órgão..."
+                  value={licitacao}
+                  onChange={(e) => setLicitacao(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Select value={portal} onValueChange={(v) => setPortal(v || undefined)}>
+                  <SelectTrigger className="w-40">
+                    <SelectValue placeholder="Portal" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="COMPRASNET">Comprasnet</SelectItem>
+                    <SelectItem value="BNC">BNC</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select value={resultado} onValueChange={(v) => setResultado(v || undefined)}>
+                  <SelectTrigger className="w-40">
+                    <SelectValue placeholder="Resultado" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="GANHOU">Ganhou</SelectItem>
+                    <SelectItem value="PERDEU">Perdeu</SelectItem>
+                    <SelectItem value="CANCELOU">Cancelou</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="date"
+                  value={dataInicio}
+                  onChange={(e) => setDataInicio(e.target.value)}
+                  className="w-40"
+                />
+                <Input
+                  type="date"
+                  value={dataFim}
+                  onChange={(e) => setDataFim(e.target.value)}
+                  className="w-40"
+                />
+                <Button type="submit" className="whitespace-nowrap">
+                  Filtrar
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card className="border-slate-200">
+          <CardHeader>
+            <CardTitle className="text-lg font-heading">Disputas encerradas</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {items.length === 0 ? (
+              <p className="text-sm text-slate-500 py-4">Nenhuma disputa encerrada encontrada.</p>
+            ) : (
+              <div className="space-y-3">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Licitação</TableHead>
+                      <TableHead>Órgão</TableHead>
+                      <TableHead>Portal</TableHead>
+                      <TableHead>Resultado</TableHead>
+                      <TableHead>Início</TableHead>
+                      <TableHead>Encerramento</TableHead>
+                      <TableHead className="text-right">Economia</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((item) => (
+                      <TableRow
+                        key={item.id}
+                        className="cursor-pointer hover:bg-slate-50"
+                        onClick={() => router.push(`/disputa/historico/${item.id}`)}
+                      >
+                        <TableCell className="font-medium">
+                          {item.bid?.title ?? "Disputa sem licitação vinculada"}
+                        </TableCell>
+                        <TableCell>{item.bid?.agency ?? "-"}</TableCell>
+                        <TableCell>{item.portal}</TableCell>
+                        <TableCell>{item.resultado}</TableCell>
+                        <TableCell>
+                          {item.iniciadoEm
+                            ? new Date(item.iniciadoEm).toLocaleString("pt-BR")
+                            : "-"}
+                        </TableCell>
+                        <TableCell>
+                          {item.encerradoEm
+                            ? new Date(item.encerradoEm).toLocaleString("pt-BR")
+                            : "-"}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          R$ {item.economia.toFixed(2)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+
+                {totalPages > 1 && (
+                  <div className="flex justify-between items-center pt-2 text-sm text-slate-600">
+                    <span>
+                      Página {page} de {totalPages}
+                    </span>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={page === 1 || loading}
+                        onClick={() => setPage((p) => Math.max(1, p - 1))}
+                      >
+                        Anterior
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={page === totalPages || loading}
+                        onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                      >
+                        Próxima
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+}
+

--- a/apps/web/src/app/disputa/page.tsx
+++ b/apps/web/src/app/disputa/page.tsx
@@ -85,7 +85,12 @@ export default function DisputaPage() {
               <h1 className="text-3xl font-heading font-extrabold text-gray-900 dark:text-gray-100">Disputas</h1>
               <p className="text-gray-500 dark:text-gray-400">Gerencie e monitore suas sessões de lance automático</p>
             </div>
-            <NovaDisputaModal onSuccess={() => void refetch()} />
+            <div className="flex gap-3">
+              <Link href="/disputa/historico">
+                <Button variant="outline">Histórico</Button>
+              </Link>
+              <NovaDisputaModal onSuccess={() => void refetch()} />
+            </div>
           </div>
 
           <Tabs value={aba} onValueChange={(value) => setAba(value as AbaStatus)}>


### PR DESCRIPTION
- API: endpoints /disputa/historico, /disputa/historico/:id e /disputa/historico/:id/pdf
- API: filtros de histórico por portal, resultado (ganhou/perdeu/cancelou), período e licitação
- API: cálculo de métricas (economia total, valor máximo total, melhor lance, duração, total de lances e último lance enviado)
- Web: página /disputa/historico com listagem filtrável e paginação
- Web: página /disputa/historico/[id] com resumo, timeline completa, gráfico de evolução e comparativo de lances
- Web: botão de exportação de PDF a partir da página de detalhes

