### PR TITLE
feat(f26-05): alertas de pregão por email + UX monitoramento

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm --filter @licitafacil/web build)",
+      "Bash(pkill -f 'next dev')",
+      "Bash(pkill -f 'nest start')",
+      "Bash(lsof -ti:3000,3001,3002)",
+      "Bash(docker run:*)",
+      "Bash(docker start:*)",
+      "Read(//tmp/**)",
+      "Bash(lsof -ti:3001)",
+      "Bash(lsof -ti:3000)",
+      "Bash(kill -9 375758)",
+      "Bash(kill -9 375648)",
+      "Bash(kill -9 375696)",
+      "Bash(pkill -f ts-node)",
+      "Bash(lsof -ti:3002)",
+      "Bash(curl -s -o /dev/null -w \"%{http_code}\" http://localhost:3000/)",
+      "Bash(lsof -ti:3000,3001)",
+      "Bash(kill -9 389293)",
+      "Bash(kill -9 396595)",
+      "Bash(sort find:*)",
+      "Bash(gh pr:*)",
+      "Bash(pnpm prisma:*)"
+    ],
+    "additionalDirectories": [
+      "/home/murilo/Área de trabalho/Limvex/licitafacil/apps/web/src/app/analise/concorrentes"
+    ]
+  }
+}

--- a/apps/api/prisma/migrations/20260317193923_add_minutos_alerta_pregao/migration.sql
+++ b/apps/api/prisma/migrations/20260317193923_add_minutos_alerta_pregao/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "empresas" ADD COLUMN     "minutosAlertaPregao" INTEGER NOT NULL DEFAULT 15;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,6 +60,8 @@ model Empresa {
   // Relacionamento: Uma empresa tem muitos pregões monitorados
   pregoesMonitorados PregaoMonitorado[]
 
+  minutosAlertaPregao Int @default(15)
+
   @@index([deletedAt]) // Otimizar queries que filtram deletados
   @@map("empresas")
 }

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -232,4 +232,70 @@ export class EmailService {
       return false;
     }
   }
+
+  async enviarAlertaPregao(dados: {
+    to: string;
+    numeroPregao: string;
+    objeto: string;
+    portal: string;
+    horarioInicio: Date;
+    urlSalaDisputa: string;
+  }): Promise<boolean> {
+    const horario = new Date(dados.horarioInicio).toLocaleString("pt-BR", {
+      timeZone: "America/Sao_Paulo",
+      hour: "2-digit",
+      minute: "2-digit",
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+
+    const html = `
+      <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto">
+        <div style="background:#2563EB;padding:24px;border-radius:8px 8px 0 0">
+          <h1 style="color:white;margin:0;font-size:20px">Pregão iniciando em breve</h1>
+        </div>
+        <div style="background:#f8fafc;padding:24px;border:1px solid #e2e8f0;border-top:none">
+          <p style="color:#374151;font-size:15px;margin:0 0 16px">
+            O pregão abaixo está prestes a iniciar. Acesse o portal para participar.
+          </p>
+          <table style="width:100%;border-collapse:collapse">
+            <tr>
+              <td style="padding:8px;background:#fff;border:1px solid #e2e8f0;font-weight:bold;width:35%">Número</td>
+              <td style="padding:8px;background:#fff;border:1px solid #e2e8f0">${dados.numeroPregao}</td>
+            </tr>
+            <tr>
+              <td style="padding:8px;background:#f8fafc;border:1px solid #e2e8f0;font-weight:bold">Portal</td>
+              <td style="padding:8px;background:#f8fafc;border:1px solid #e2e8f0">${dados.portal}</td>
+            </tr>
+            <tr>
+              <td style="padding:8px;background:#fff;border:1px solid #e2e8f0;font-weight:bold">Horário</td>
+              <td style="padding:8px;background:#fff;border:1px solid #e2e8f0">${horario}</td>
+            </tr>
+            <tr>
+              <td style="padding:8px;background:#f8fafc;border:1px solid #e2e8f0;font-weight:bold">Objeto</td>
+              <td style="padding:8px;background:#f8fafc;border:1px solid #e2e8f0">${(dados.objeto ?? "").slice(0, 200)}</td>
+            </tr>
+          </table>
+          <div style="text-align:center;margin-top:24px">
+            <a href="${dados.urlSalaDisputa}"
+              style="background:#2563EB;color:white;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:bold;font-size:15px">
+              Abrir sala de disputa
+            </a>
+          </div>
+        </div>
+        <div style="padding:16px;text-align:center">
+          <p style="color:#9ca3af;font-size:12px;margin:0">
+            Limvex Licitação — Gestão inteligente de processos licitatórios
+          </p>
+        </div>
+      </div>
+    `;
+
+    return this.sendEmail({
+      to: dados.to,
+      subject: `Pregão ${dados.numeroPregao} inicia em breve — ${dados.portal}`,
+      html,
+    });
+  }
 }

--- a/apps/api/src/empresa/empresa.controller.ts
+++ b/apps/api/src/empresa/empresa.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Body,
   Param,
   HttpCode,
@@ -55,10 +56,35 @@ export class EmpresaController {
   }
 
   /**
+   * Busca a configuração de alerta de pregão
+   * GET /empresas/configuracoes/alertas
+   */
+  @Get("configuracoes/alertas")
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async getConfigAlerta(@Tenant() empresaId: string) {
+    return this.empresaService.getConfigAlerta(empresaId);
+  }
+
+  /**
+   * Salva a configuração de alerta de pregão
+   * PATCH /empresas/configuracoes/alertas
+   */
+  @Patch("configuracoes/alertas")
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async updateConfigAlerta(
+    @Tenant() empresaId: string,
+    @Body() body: { minutosAlertaPregao: number },
+  ) {
+    return this.empresaService.updateConfigAlerta(empresaId, body.minutosAlertaPregao);
+  }
+
+  /**
    * Busca uma empresa por ID (com validação de tenant)
    * GET /empresas/:id
    * Só permite buscar a própria empresa
-   * 
+   *
    * Permissão: ADMIN e COLABORADOR podem ver
    */
   @Get(":id")

--- a/apps/api/src/empresa/empresa.service.ts
+++ b/apps/api/src/empresa/empresa.service.ts
@@ -83,4 +83,21 @@ export class EmpresaService {
 
     return !!empresa;
   }
+
+  async getConfigAlerta(empresaId: string): Promise<{ minutosAlertaPregao: number }> {
+    const empresa = await this.prisma.empresa.findUnique({
+      where: { id: empresaId },
+      select: { minutosAlertaPregao: true },
+    });
+    return { minutosAlertaPregao: empresa?.minutosAlertaPregao ?? 15 };
+  }
+
+  async updateConfigAlerta(empresaId: string, minutos: number): Promise<{ minutosAlertaPregao: number }> {
+    const empresa = await this.prisma.empresa.update({
+      where: { id: empresaId },
+      data: { minutosAlertaPregao: minutos },
+      select: { minutosAlertaPregao: true },
+    });
+    return { minutosAlertaPregao: empresa.minutosAlertaPregao };
+  }
 }

--- a/apps/api/src/monitoramento/adapters/pncp.adapter.ts
+++ b/apps/api/src/monitoramento/adapters/pncp.adapter.ts
@@ -80,6 +80,7 @@ export class PncpAdapter implements PortalAdapter {
             numeroPregao: item.numeroCompra || numeroControle || '',
             objeto: item.objetoCompra || '',
             orgao: item.orgaoEntidade?.razaoSocial || item.unidadeOrgao?.nomeUnidade || '',
+            uf: item.unidadeOrgao?.ufSigla || item.orgaoEntidade?.ufSigla || '',
             horarioInicio: new Date(item.dataAberturaProposta || item.dataPublicacaoPncp),
             urlSalaDisputa: link || urlFallbackPncp,
             urlFallbackPncp,

--- a/apps/api/src/monitoramento/adapters/portal.adapter.ts
+++ b/apps/api/src/monitoramento/adapters/portal.adapter.ts
@@ -4,6 +4,7 @@ export interface PregaoInfo {
   numeroPregao: string
   objeto: string
   orgao: string
+  uf?: string
   horarioInicio: Date
   urlSalaDisputa: string
   urlFallbackPncp?: string

--- a/apps/api/src/monitoramento/monitoramento-alerta.processor.ts
+++ b/apps/api/src/monitoramento/monitoramento-alerta.processor.ts
@@ -1,0 +1,55 @@
+import { Process, Processor } from '@nestjs/bull'
+import { Job } from 'bull'
+import { Logger } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { EmailService } from '../email/email.service'
+
+@Processor('monitoramento-alertas')
+export class MonitoramentoAlertaProcessor {
+  private readonly logger = new Logger(MonitoramentoAlertaProcessor.name)
+
+  constructor(
+    private prisma: PrismaService,
+    private emailService: EmailService,
+  ) {}
+
+  @Process('enviar-alerta-pregao')
+  async enviarAlerta(job: Job<{ pregaoId: string; empresaId: string }>) {
+    const { pregaoId } = job.data
+
+    const pregao = await this.prisma.pregaoMonitorado.findUnique({
+      where: { id: pregaoId },
+      include: {
+        empresa: {
+          include: {
+            users: { where: { deletedAt: null }, take: 5 },
+          },
+        },
+      },
+    })
+
+    if (!pregao || pregao.alertaEnviado) return
+    if (pregao.status === 'ENCERRADO' || pregao.status === 'CANCELADO') return
+
+    const emails = pregao.empresa.users.map((u) => u.email).filter(Boolean) as string[]
+    if (emails.length === 0) return
+
+    for (const email of emails) {
+      await this.emailService.enviarAlertaPregao({
+        to: email,
+        numeroPregao: pregao.numeroPregao,
+        objeto: pregao.objeto,
+        portal: pregao.portal,
+        horarioInicio: pregao.horarioInicio,
+        urlSalaDisputa: pregao.urlSalaDisputa,
+      })
+    }
+
+    await this.prisma.pregaoMonitorado.update({
+      where: { id: pregaoId },
+      data: { alertaEnviado: true },
+    })
+
+    this.logger.log(`Alerta enviado para pregão ${pregaoId} — ${emails.length} email(s)`)
+  }
+}

--- a/apps/api/src/monitoramento/monitoramento.module.ts
+++ b/apps/api/src/monitoramento/monitoramento.module.ts
@@ -4,19 +4,24 @@ import { MonitoramentoController } from './monitoramento.controller'
 import { MonitoramentoService } from './monitoramento.service'
 import { MonitoramentoGateway } from './monitoramento.gateway'
 import { MonitoramentoProcessor } from './monitoramento.processor'
+import { MonitoramentoAlertaProcessor } from './monitoramento-alerta.processor'
 import { PncpAdapter } from './adapters/pncp.adapter'
 import { PrismaModule } from '../prisma/prisma.module'
+import { EmailModule } from '../email/email.module'
 
 @Module({
   imports: [
     PrismaModule,
+    EmailModule,
     BullModule.registerQueue({ name: 'monitoramento' }),
+    BullModule.registerQueue({ name: 'monitoramento-alertas' }),
   ],
   controllers: [MonitoramentoController],
   providers: [
     MonitoramentoService,
     MonitoramentoGateway,
     MonitoramentoProcessor,
+    MonitoramentoAlertaProcessor,
     PncpAdapter,
   ],
   exports: [MonitoramentoService, MonitoramentoGateway],

--- a/apps/api/src/monitoramento/monitoramento.service.ts
+++ b/apps/api/src/monitoramento/monitoramento.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from '@nestjs/common'
+import { Injectable, BadRequestException, Logger } from '@nestjs/common'
 import { InjectQueue } from '@nestjs/bull'
 import { Queue } from 'bull'
 import { PrismaService } from '../prisma/prisma.service'
@@ -9,10 +9,13 @@ import { Prisma } from '@prisma/client'
 
 @Injectable()
 export class MonitoramentoService {
+  private readonly logger = new Logger(MonitoramentoService.name)
+
   constructor(
     private prisma: PrismaService,
     private pncpAdapter: PncpAdapter,
     @InjectQueue('monitoramento') private monitoramentoQueue: Queue,
+    @InjectQueue('monitoramento-alertas') private alertasQueue: Queue,
   ) {}
 
   async listarPregoes(empresaId: string, filtros: FiltrosPregaoDto) {
@@ -101,6 +104,24 @@ export class MonitoramentoService {
       { pregaoId: pregao.id, empresaId },
       { repeat: { every: 60000 }, jobId: `monitor-${pregao.id}` },
     )
+
+    // Agendar alerta por email
+    const empresa = await this.prisma.empresa.findUnique({
+      where: { id: empresaId },
+      select: { minutosAlertaPregao: true },
+    })
+    const minutosAntes = empresa?.minutosAlertaPregao ?? 15
+    const horarioAlerta = new Date(pregao.horarioInicio)
+    horarioAlerta.setMinutes(horarioAlerta.getMinutes() - minutosAntes)
+    const delay = horarioAlerta.getTime() - Date.now()
+    if (delay > 0) {
+      await this.alertasQueue.add(
+        'enviar-alerta-pregao',
+        { pregaoId: pregao.id, empresaId },
+        { delay, attempts: 2 },
+      )
+      this.logger.log(`Alerta agendado para ${minutosAntes}min antes do pregão ${pregao.id}`)
+    }
 
     return pregao
   }

--- a/apps/web/src/app/configuracoes/page.tsx
+++ b/apps/web/src/app/configuracoes/page.tsx
@@ -9,6 +9,8 @@ import {
 import { useAuth } from "@/contexts/auth-context";
 import { cn } from "@/lib/utils";
 import { useState, useEffect } from "react";
+import { getConfigAlertaPregao, saveConfigAlertaPregao } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
 
 /* ─── Theme helper ─────────────────────────────────────────── */
 type ThemeOption = "light" | "dark" | "system";
@@ -79,11 +81,27 @@ function SectionCard({
 
 export default function ConfiguracoesPage() {
     const { user } = useAuth();
+    const { toast } = useToast();
     const [theme, setTheme] = useState<ThemeOption>("system");
+    const [minutosAlerta, setMinutosAlerta] = useState(15);
+    const [salvandoAlerta, setSalvandoAlerta] = useState(false);
 
     useEffect(() => {
         setTheme(getStoredTheme());
+        getConfigAlertaPregao().then(r => setMinutosAlerta(r.minutosAlertaPregao)).catch(() => {});
     }, []);
+
+    async function salvarAlerta() {
+        setSalvandoAlerta(true);
+        try {
+            await saveConfigAlertaPregao(minutosAlerta);
+            toast({ title: "Configuração salva", description: "Alerta de pregão atualizado." });
+        } catch {
+            toast({ title: "Erro", description: "Não foi possível salvar.", variant: "destructive" });
+        } finally {
+            setSalvandoAlerta(false);
+        }
+    }
 
     function handleThemeChange(t: ThemeOption) {
         setTheme(t);
@@ -197,6 +215,54 @@ export default function ConfiguracoesPage() {
                                 </button>
                             ))}
                         </div>
+                    </div>
+                </div>
+
+                {/* Section: Alertas de Pregão */}
+                <div className="space-y-3">
+                    <p className="text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider px-1">
+                        Monitoramento
+                    </p>
+                    <div className="p-5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 space-y-4">
+                        <div>
+                            <p className="font-semibold text-slate-900 dark:text-slate-100 text-[15px] mb-0.5">Alertas de Pregão</p>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                                Receba um email antes do horário de início dos pregões monitorados.
+                            </p>
+                        </div>
+                        <div className="space-y-3">
+                            <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                                Alertar quantos minutos antes?
+                            </p>
+                            <div className="flex items-center gap-2 flex-wrap">
+                                {[5, 10, 15, 30, 60].map(min => (
+                                    <button
+                                        key={min}
+                                        onClick={() => setMinutosAlerta(min)}
+                                        className={cn(
+                                            "px-4 py-2 rounded-lg text-sm font-medium border transition-all duration-150",
+                                            minutosAlerta === min
+                                                ? "bg-blue-600 text-white border-blue-600"
+                                                : "bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 border-slate-200 dark:border-slate-700 hover:border-blue-400 dark:hover:border-blue-600"
+                                        )}
+                                    >
+                                        {min >= 60 ? "1h" : `${min}min`}
+                                    </button>
+                                ))}
+                            </div>
+                            <p className="text-xs text-slate-500 dark:text-slate-400">
+                                Você receberá um email{" "}
+                                {minutosAlerta >= 60 ? "1 hora" : `${minutosAlerta} minutos`}{" "}
+                                antes do início de cada pregão que você monitorar.
+                            </p>
+                        </div>
+                        <button
+                            onClick={salvarAlerta}
+                            disabled={salvandoAlerta}
+                            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                        >
+                            {salvandoAlerta ? "Salvando..." : "Salvar configuração"}
+                        </button>
                     </div>
                 </div>
 

--- a/apps/web/src/app/monitoramento/page.tsx
+++ b/apps/web/src/app/monitoramento/page.tsx
@@ -31,6 +31,7 @@ function MonitoramentoContent() {
   const [pregoes, setPregoes] = useState<PregaoMonitorado[]>([])
   const [carregando, setCarregando] = useState(true)
   const [filtroPortal, setFiltroPortal] = useState('')
+  const [filtroUf, setFiltroUf] = useState('')
   const [dataFiltro, setDataFiltro] = useState(new Date().toISOString().slice(0, 10))
   const [busca, setBusca] = useState('')
   const [pagina, setPagina] = useState(1)
@@ -82,7 +83,7 @@ function MonitoramentoContent() {
 
   useEffect(() => { carregar() }, [carregar])
 
-  useEffect(() => { setPagina(1) }, [filtroPortal, dataFiltro, busca])
+  useEffect(() => { setPagina(1) }, [filtroPortal, filtroUf, dataFiltro, busca])
 
   useEffect(() => {
     if (!mostrarAdicionar) return
@@ -127,6 +128,7 @@ function MonitoramentoContent() {
 
   const pregoesFiltrados = pregoes.filter(p => {
     if (filtroPortal && p.portal !== filtroPortal) return false
+    if (filtroUf && p.uf !== filtroUf) return false
     if (busca.trim()) {
       const q = busca.toLowerCase()
       if (!p.objeto?.toLowerCase().includes(q) &&
@@ -283,6 +285,34 @@ function MonitoramentoContent() {
         </div>
       )}
 
+      {!carregando && pregoes.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {[
+            { label: 'Total hoje', valor: pregoes.length, cor: 'text-foreground' },
+            {
+              label: 'Com link direto',
+              valor: pregoes.filter(p => p.urlSalaDisputa && !p.urlSalaDisputa.includes('pncp.gov.br')).length,
+              cor: 'text-green-400',
+            },
+            {
+              label: 'Portais',
+              valor: [...new Set(pregoes.map(p => p.portal))].length,
+              cor: 'text-blue-400',
+            },
+            {
+              label: 'Estados',
+              valor: [...new Set(pregoes.map(p => p.uf).filter(Boolean))].length,
+              cor: 'text-purple-400',
+            },
+          ].map(item => (
+            <div key={item.label} className="bg-card border border-border rounded-lg p-3 text-center">
+              <p className={`text-2xl font-bold ${item.cor}`}>{item.valor}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{item.label}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="flex items-center gap-3 flex-wrap">
         <div className="relative">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
@@ -308,6 +338,16 @@ function MonitoramentoContent() {
           <option value="">Todos os portais</option>
           <option value="BNC">BNC</option>
           <option value="PNCP">PNCP</option>
+        </select>
+        <select
+          value={filtroUf}
+          onChange={e => { setFiltroUf(e.target.value); setPagina(1) }}
+          className="px-3 py-1.5 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-primary"
+        >
+          <option value="">Todos os estados</option>
+          {['AC','AL','AM','AP','BA','CE','DF','ES','GO','MA','MG','MS','MT',
+            'PA','PB','PE','PI','PR','RJ','RN','RO','RR','RS','SC','SE','SP','TO']
+            .map(uf => <option key={uf} value={uf}>{uf}</option>)}
         </select>
         <span className="text-xs text-muted-foreground ml-auto">
           {carregando

--- a/apps/web/src/components/monitoramento/CardPregao.tsx
+++ b/apps/web/src/components/monitoramento/CardPregao.tsx
@@ -7,6 +7,7 @@ export interface PregaoMonitorado {
   numeroPregao: string
   objeto: string
   orgao: string
+  uf?: string
   portal: string
   status: string
   horarioInicio: string
@@ -99,6 +100,7 @@ export function CardPregao({ pregao }: CardPregaoProps) {
         </p>
         <p className="text-xs text-muted-foreground mt-0.5">
           {pregao.numeroPregao} · {pregao.orgao}
+          {pregao.uf && <span className="ml-1 text-muted-foreground/60">· {pregao.uf}</span>}
         </p>
       </div>
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -643,3 +643,13 @@ export async function updateChecklistItem(id: string, body: { titulo?: string; d
 export async function deleteChecklistItem(id: string): Promise<void> {
   await api.delete(`/checklist-items/${id}`);
 }
+
+// --- Config alertas pregão ---
+export async function getConfigAlertaPregao(): Promise<{ minutosAlertaPregao: number }> {
+  const { data } = await api.get('/empresas/configuracoes/alertas');
+  return data;
+}
+
+export async function saveConfigAlertaPregao(minutos: number): Promise<void> {
+  await api.patch('/empresas/configuracoes/alertas', { minutosAlertaPregao: minutos });
+}


### PR DESCRIPTION
## F26-05 — Alertas de Pregão + Melhorias UX

### Backend
- `MonitoramentoAlertaProcessor` — job BullMQ que envia email X minutos antes do pregão iniciar
- Campo `minutosAlertaPregao` na model `Empresa` (padrão: 15min)
- Template HTML de alerta com dados do pregão e botão de acesso
- Endpoints `GET/PATCH /empresas/configuracoes/alertas`
- Log de `alertaEnviado` para evitar duplicatas

### Frontend
- Seção **Monitoramento** em `/configuracoes` com botões 5/10/15/30/60min
- Resumo do dia no topo do painel (total, com link direto, portais, estados)
- Filtro por UF com todos os 27 estados brasileiros
- UF exibida nos cards ao lado do órgão

### Typecheck ✅  Build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)