### PR TITLE
feat(negocios): central de pregões com registro de resultado e economia

### DIFF
--- a/apps/api/prisma/migrations/20260318140138_add_resultado_pregao_central/migration.sql
+++ b/apps/api/prisma/migrations/20260318140138_add_resultado_pregao_central/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "ResultadoPregao" AS ENUM ('GANHOU', 'PERDEU', 'DESISTIU', 'PENDENTE');
+
+-- CreateEnum
+CREATE TYPE "FonteValorReferenciaPregao" AS ENUM ('PNCP', 'EDITAL', 'MANUAL');
+
+-- AlterTable
+ALTER TABLE "PregaoMonitorado" ADD COLUMN     "finalizadoEm" TIMESTAMP(3),
+ADD COLUMN     "fonteValorReferencia" "FonteValorReferenciaPregao",
+ADD COLUMN     "observacao" TEXT,
+ADD COLUMN     "resultado" "ResultadoPregao" NOT NULL DEFAULT 'PENDENTE',
+ADD COLUMN     "valorFinal" DOUBLE PRECISION,
+ADD COLUMN     "valorReferencia" DOUBLE PRECISION;
+
+-- CreateIndex
+CREATE INDEX "PregaoMonitorado_empresaId_resultado_idx" ON "PregaoMonitorado"("empresaId", "resultado");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -901,6 +901,19 @@ enum StatusPregao {
   CANCELADO
 }
 
+enum ResultadoPregao {
+  GANHOU
+  PERDEU
+  DESISTIU
+  PENDENTE
+}
+
+enum FonteValorReferenciaPregao {
+  PNCP
+  EDITAL
+  MANUAL
+}
+
 model PregaoMonitorado {
   id             String              @id @default(uuid())
   empresaId      String
@@ -915,6 +928,15 @@ model PregaoMonitorado {
   urlSalaDisputa String
   linkPncp       String?
   melhorLance    Float?
+
+  // Central de Pregões (registro manual de resultado)
+  resultado      ResultadoPregao     @default(PENDENTE)
+  valorFinal     Float?
+  valorReferencia Float?
+  fonteValorReferencia FonteValorReferenciaPregao?
+  observacao     String?
+  finalizadoEm   DateTime?
+
   alertaEnviado  Boolean             @default(false)
   createdAt      DateTime            @default(now())
   updatedAt      DateTime            @updatedAt
@@ -923,6 +945,7 @@ model PregaoMonitorado {
   bid           Bid?                @relation(fields: [bidId], references: [id], onDelete: SetNull)
 
   @@index([empresaId, status])
+  @@index([empresaId, resultado])
   @@index([horarioInicio])
   @@index([bidId])
 }

--- a/apps/api/src/monitoramento/dto/filtros-central-pregoes.dto.ts
+++ b/apps/api/src/monitoramento/dto/filtros-central-pregoes.dto.ts
@@ -1,0 +1,46 @@
+import { IsEnum, IsOptional, IsString, Matches } from 'class-validator'
+import { PortalMonitoramento, ResultadoPregao } from '@prisma/client'
+
+export enum PeriodoCentralPregoes {
+  INICIO = 'INICIO',
+  FINALIZACAO = 'FINALIZACAO',
+}
+
+export class FiltrosCentralPregoesDto {
+  @IsOptional()
+  @IsEnum(PortalMonitoramento)
+  portal?: PortalMonitoramento
+
+  @IsOptional()
+  @IsEnum(ResultadoPregao)
+  resultado?: ResultadoPregao
+
+  @IsOptional()
+  @IsEnum(PeriodoCentralPregoes)
+  periodoPor?: PeriodoCentralPregoes
+
+  // yyyy-MM-dd
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  dataInicio?: string
+
+  // yyyy-MM-dd
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  dataFim?: string
+
+  @IsOptional()
+  @IsString()
+  licitacao?: string
+
+  @IsOptional()
+  @IsString()
+  page?: string
+
+  @IsOptional()
+  @IsString()
+  limit?: string
+}
+

--- a/apps/api/src/monitoramento/dto/registrar-resultado-pregao.dto.ts
+++ b/apps/api/src/monitoramento/dto/registrar-resultado-pregao.dto.ts
@@ -1,0 +1,29 @@
+import { IsEnum, IsNumber, IsOptional, IsString, Min } from 'class-validator'
+import { Transform } from 'class-transformer'
+import { FonteValorReferenciaPregao, ResultadoPregao } from '@prisma/client'
+
+export class RegistrarResultadoPregaoDto {
+  @IsEnum(ResultadoPregao)
+  resultado!: ResultadoPregao
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' || value === null || value === undefined ? undefined : Number(value)))
+  @IsNumber()
+  @Min(0)
+  valorFinal?: number
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' || value === null || value === undefined ? undefined : Number(value)))
+  @IsNumber()
+  @Min(0)
+  valorReferencia?: number
+
+  @IsOptional()
+  @IsEnum(FonteValorReferenciaPregao)
+  fonteValorReferencia?: FonteValorReferenciaPregao
+
+  @IsOptional()
+  @IsString()
+  observacao?: string
+}
+

--- a/apps/api/src/monitoramento/monitoramento.controller.ts
+++ b/apps/api/src/monitoramento/monitoramento.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Get, Post, Patch, Delete, Param, Query, Body, Req, UseGuards } from '@nestjs/common'
+import { Controller, Get, Post, Patch, Delete, Param, Query, Body, Req, UseGuards, Header } from '@nestjs/common'
 import { MonitoramentoService } from './monitoramento.service'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
 import { FiltrosPregaoDto } from './dto/filtros-pregao.dto'
 import { CadastrarPregaoDto } from './dto/cadastrar-pregao.dto'
 import { AtualizarPregaoDto } from './dto/atualizar-pregao.dto'
+import { RegistrarResultadoPregaoDto } from './dto/registrar-resultado-pregao.dto'
+import { FiltrosCentralPregoesDto } from './dto/filtros-central-pregoes.dto'
 
 @Controller('monitoramento')
 @UseGuards(JwtAuthGuard)
@@ -29,6 +31,29 @@ export class MonitoramentoController {
   @Post('pregoes')
   async cadastrar(@Req() req: any, @Body() dto: CadastrarPregaoDto) {
     return this.service.cadastrarPregao(req.user.empresaId, dto)
+  }
+
+  // Central de Pregões (resultados)
+  @Get('pregoes/resultados')
+  async listarResultados(@Req() req: any, @Query() filtros: FiltrosCentralPregoesDto) {
+    return this.service.listarResultadosPregoes(req.user.empresaId, filtros)
+  }
+
+  @Get('pregoes/metricas')
+  async metricas(@Req() req: any, @Query() filtros: FiltrosCentralPregoesDto) {
+    return this.service.metricasPregoes(req.user.empresaId, filtros)
+  }
+
+  @Get('pregoes/exportar-csv')
+  @Header('Content-Type', 'text/csv; charset=utf-8')
+  @Header('Content-Disposition', 'attachment; filename="pregoes.csv"')
+  async exportarCsv(@Req() req: any, @Query() filtros: FiltrosCentralPregoesDto) {
+    return this.service.exportarResultadosCsv(req.user.empresaId, filtros)
+  }
+
+  @Patch('pregoes/:id/resultado')
+  async registrarResultado(@Req() req: any, @Param('id') id: string, @Body() dto: RegistrarResultadoPregaoDto) {
+    return this.service.registrarResultadoPregao(id, req.user.empresaId, dto)
   }
 
   @Patch('pregoes/:id')

--- a/apps/api/src/monitoramento/monitoramento.service.ts
+++ b/apps/api/src/monitoramento/monitoramento.service.ts
@@ -7,6 +7,8 @@ import { FiltrosPregaoDto } from './dto/filtros-pregao.dto'
 import { CadastrarPregaoDto } from './dto/cadastrar-pregao.dto'
 import { AtualizarPregaoDto } from './dto/atualizar-pregao.dto'
 import { Prisma } from '@prisma/client'
+import { RegistrarResultadoPregaoDto } from './dto/registrar-resultado-pregao.dto'
+import { FiltrosCentralPregoesDto, PeriodoCentralPregoes } from './dto/filtros-central-pregoes.dto'
 
 @Injectable()
 export class MonitoramentoService {
@@ -240,5 +242,206 @@ export class MonitoramentoService {
         ...(dto.bidId !== undefined ? { bidId: dto.bidId } : {}),
       },
     })
+  }
+
+  private parseLocalDateOnly(s?: string, endOfDay?: boolean) {
+    if (!s) return null
+    const [y, m, d] = s.split('-').map((v) => parseInt(v, 10))
+    if (!y || !m || !d) return null
+    const dt = new Date(y, m - 1, d)
+    if (endOfDay) dt.setHours(23, 59, 59, 999)
+    else dt.setHours(0, 0, 0, 0)
+    return dt
+  }
+
+  private buildCentralWhere(empresaId: string, filtros: FiltrosCentralPregoesDto) {
+    const inicio = this.parseLocalDateOnly(filtros.dataInicio, false)
+    const fim = this.parseLocalDateOnly(filtros.dataFim, true)
+    const lic = (filtros.licitacao ?? '').trim()
+    const periodoPor = filtros.periodoPor ?? PeriodoCentralPregoes.INICIO
+
+    return {
+      empresaId,
+      ...(filtros.portal && { portal: filtros.portal }),
+      ...(filtros.resultado && { resultado: filtros.resultado }),
+      ...(inicio || fim
+        ? {
+          ...(periodoPor === PeriodoCentralPregoes.FINALIZACAO
+            ? {
+              finalizadoEm: {
+                ...(inicio ? { gte: inicio } : {}),
+                ...(fim ? { lte: fim } : {}),
+              },
+            }
+            : {
+              // default: início do pregão
+              horarioInicio: {
+                ...(inicio ? { gte: inicio } : {}),
+                ...(fim ? { lte: fim } : {}),
+              },
+            }),
+        }
+        : {}),
+      ...(lic
+        ? {
+          OR: [
+            { numeroPregao: { contains: lic, mode: 'insensitive' as const } },
+            { objeto: { contains: lic, mode: 'insensitive' as const } },
+            { orgao: { contains: lic, mode: 'insensitive' as const } },
+            { bid: { title: { contains: lic, mode: 'insensitive' as const } } },
+            { bid: { agency: { contains: lic, mode: 'insensitive' as const } } },
+          ],
+        }
+        : {}),
+    } satisfies Prisma.PregaoMonitoradoWhereInput
+  }
+
+  async registrarResultadoPregao(id: string, empresaId: string, dto: RegistrarResultadoPregaoDto) {
+    const agora = new Date()
+
+    return this.prisma.pregaoMonitorado.update({
+      where: { id, empresaId },
+      data: {
+        resultado: dto.resultado,
+        valorFinal: dto.valorFinal ?? null,
+        valorReferencia: dto.valorReferencia ?? null,
+        fonteValorReferencia: dto.fonteValorReferencia ?? null,
+        observacao: dto.observacao ?? null,
+        finalizadoEm: dto.resultado === 'PENDENTE' ? null : agora,
+      },
+    })
+  }
+
+  async listarResultadosPregoes(empresaId: string, filtros: FiltrosCentralPregoesDto) {
+    const page = Math.max(parseInt(filtros.page ?? '1', 10) || 1, 1)
+    const limit = Math.min(Math.max(parseInt(filtros.limit ?? '10', 10) || 10, 1), 50)
+    const skip = (page - 1) * limit
+
+    const where = this.buildCentralWhere(empresaId, filtros)
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.pregaoMonitorado.findMany({
+        where,
+        include: { bid: { select: { id: true, title: true, agency: true } } },
+        orderBy: [{ finalizadoEm: 'desc' }, { horarioInicio: 'desc' }],
+        skip,
+        take: limit,
+      }),
+      this.prisma.pregaoMonitorado.count({ where }),
+    ])
+
+    return {
+      page,
+      limit,
+      total,
+      items,
+    }
+  }
+
+  async metricasPregoes(empresaId: string, filtros: FiltrosCentralPregoesDto) {
+    const where = this.buildCentralWhere(empresaId, filtros)
+
+    const [counts, economiaAgg, totalCount, finalAgg, refAgg] = await this.prisma.$transaction([
+      this.prisma.pregaoMonitorado.groupBy({
+        by: ['resultado'],
+        where,
+        orderBy: { resultado: 'asc' },
+        _count: { _all: true },
+      }),
+      this.prisma.pregaoMonitorado.aggregate({
+        where: {
+          ...where,
+          valorFinal: { not: null },
+          valorReferencia: { not: null },
+        },
+        _sum: {
+          valorFinal: true,
+          valorReferencia: true,
+        },
+        _count: { _all: true },
+      }),
+      this.prisma.pregaoMonitorado.count({ where }),
+      this.prisma.pregaoMonitorado.count({ where: { ...where, finalizadoEm: { not: null } } }),
+      this.prisma.pregaoMonitorado.count({ where: { ...where, valorReferencia: { not: null } } }),
+    ])
+
+    const sumFinal = economiaAgg._sum.valorFinal ?? 0
+    const sumRef = economiaAgg._sum.valorReferencia ?? 0
+
+    const porResultado = Object.fromEntries(
+      (counts as Array<{ resultado: any; _count: { _all: number } }>).map((c) => [c.resultado, c._count._all]),
+    )
+
+    return {
+      total: totalCount,
+      totalFinalizados: finalAgg,
+      totalComValorReferencia: refAgg,
+      porResultado,
+      economiaTotal: sumRef - sumFinal,
+      baseEconomia: {
+        totalComValores: (economiaAgg as any)?._count?._all ?? 0,
+        somaValorReferencia: sumRef,
+        somaValorFinal: sumFinal,
+      },
+    }
+  }
+
+  async exportarResultadosCsv(empresaId: string, filtros: FiltrosCentralPregoesDto) {
+    const where = this.buildCentralWhere(empresaId, filtros)
+    const items = await this.prisma.pregaoMonitorado.findMany({
+      where,
+      include: { bid: { select: { id: true, title: true } } },
+      orderBy: [{ finalizadoEm: 'desc' }, { horarioInicio: 'desc' }],
+      take: 5000,
+    })
+
+    const escape = (v: any) => {
+      const s = (v ?? '').toString()
+      const needsQuotes = /[;"\n\r]/.test(s)
+      const safe = s.replace(/"/g, '""')
+      return needsQuotes ? `"${safe}"` : safe
+    }
+
+    const header = [
+      'numeroPregao',
+      'portal',
+      'orgao',
+      'horarioInicio',
+      'resultado',
+      'valorReferencia',
+      'valorFinal',
+      'economia',
+      'licitacaoId',
+      'licitacaoTitulo',
+      'finalizadoEm',
+      'observacao',
+      'urlSalaDisputa',
+    ].join(';')
+
+    const lines = items.map((p) => {
+      const economia =
+        typeof p.valorReferencia === 'number' && typeof p.valorFinal === 'number'
+          ? p.valorReferencia - p.valorFinal
+          : ''
+      return [
+        escape(p.numeroPregao),
+        escape(p.portal),
+        escape(p.orgao),
+        escape(p.horarioInicio?.toISOString?.() ?? ''),
+        escape(p.resultado),
+        escape(p.valorReferencia ?? ''),
+        escape(p.valorFinal ?? ''),
+        escape(economia),
+        escape(p.bidId ?? ''),
+        escape(p.bid?.title ?? ''),
+        escape(p.finalizadoEm?.toISOString?.() ?? ''),
+        escape(p.observacao ?? ''),
+        escape(p.urlSalaDisputa ?? ''),
+      ].join(';')
+    })
+
+    // BOM para Excel/PT-BR
+    const csv = `\uFEFF${header}\n${lines.join('\n')}\n`
+    return csv
   }
 }

--- a/apps/web/src/app/monitoramento/page.tsx
+++ b/apps/web/src/app/monitoramento/page.tsx
@@ -4,12 +4,14 @@ import { Plus, Radio, Bell, X, Search } from 'lucide-react'
 import { CardPregao } from '@/components/monitoramento/CardPregao'
 import type { PregaoMonitorado } from '@/components/monitoramento/CardPregao'
 import { useMonitoramentoSocket } from '@/hooks/useMonitoramentoSocket'
-import { listarPregoesPncp, cadastrarPregaoMonitorado, sugerirVinculoPregao } from '@/lib/api'
+import { listarPregoesPncp, cadastrarPregaoMonitorado, sugerirVinculoPregao, registrarResultadoPregao } from '@/lib/api'
 import { useAuth } from '@/contexts/auth-context'
 import { AuthGuard } from '@/components/AuthGuard'
 import { Layout } from '@/components/layout'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -17,6 +19,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
 const ITENS_POR_PAGINA = 20
 
@@ -48,6 +59,15 @@ function MonitoramentoContent() {
   const [bidIdSelecionado, setBidIdSelecionado] = useState<string>('')
   const [vinculoQuery, setVinculoQuery] = useState<string>('')
   const [criandoLicitacaoKey, setCriandoLicitacaoKey] = useState<string>('')
+
+  const [resultadoModalOpen, setResultadoModalOpen] = useState(false)
+  const [resultadoPregao, setResultadoPregao] = useState<PregaoMonitorado | null>(null)
+  const [resultadoValorFinal, setResultadoValorFinal] = useState<string>('')
+  const [resultadoValorReferencia, setResultadoValorReferencia] = useState<string>('')
+  const [resultadoFonte, setResultadoFonte] = useState<string>('')
+  const [resultadoObs, setResultadoObs] = useState<string>('')
+  const [resultadoStatus, setResultadoStatus] = useState<string>('PENDENTE')
+  const [salvandoResultado, setSalvandoResultado] = useState(false)
 
   const { conectado, reconectando, updates, alertas } = useMonitoramentoSocket(user?.empresaId)
 
@@ -209,6 +229,55 @@ function MonitoramentoContent() {
       setErroAdicionar(e?.message || 'Erro ao adicionar pregão')
     } finally {
       setAdicionando(false)
+    }
+  }
+
+  const abrirModalResultado = (pregao: PregaoMonitorado) => {
+    if (!pregao.id) {
+      toast({
+        title: "Este pregão ainda não está salvo",
+        description: "Adicione/registre o pregão no monitoramento para poder salvar o resultado.",
+        variant: "destructive",
+      })
+      return
+    }
+    setResultadoPregao(pregao)
+    setResultadoStatus((pregao as any)?.resultado ?? 'PENDENTE')
+    setResultadoValorFinal('')
+    setResultadoValorReferencia('')
+    setResultadoFonte('')
+    setResultadoObs('')
+    setResultadoModalOpen(true)
+  }
+
+  const salvarResultado = async () => {
+    if (!resultadoPregao?.id) return
+    setSalvandoResultado(true)
+    try {
+      const valorFinal = resultadoValorFinal.trim() ? Number(resultadoValorFinal.replace(",", ".")) : null
+      const valorReferencia = resultadoValorReferencia.trim() ? Number(resultadoValorReferencia.replace(",", ".")) : null
+      if (valorFinal != null && (Number.isNaN(valorFinal) || valorFinal < 0)) throw new Error("Valor final inválido.")
+      if (valorReferencia != null && (Number.isNaN(valorReferencia) || valorReferencia < 0)) throw new Error("Valor de referência inválido.")
+
+      await registrarResultadoPregao(resultadoPregao.id, {
+        resultado: resultadoStatus as any,
+        valorFinal,
+        valorReferencia,
+        fonteValorReferencia: resultadoFonte ? (resultadoFonte as any) : null,
+        observacao: resultadoObs?.trim() || null,
+      })
+      toast({ title: "Resultado registrado", description: "Você pode acompanhar na Central de Pregões." })
+      setResultadoModalOpen(false)
+      setResultadoPregao(null)
+      carregar()
+    } catch (e: any) {
+      toast({
+        title: "Erro ao salvar resultado",
+        description: e?.response?.data?.message || e?.message || "Não foi possível salvar.",
+        variant: "destructive",
+      })
+    } finally {
+      setSalvandoResultado(false)
     }
   }
 
@@ -431,6 +500,7 @@ function MonitoramentoContent() {
                 pregao={p}
                 onCriarLicitacao={handleCriarLicitacao}
                 criandoLicitacao={criandoLicitacaoKey === `${p.portal}::${p.numeroPregao}`}
+                onRegistrarResultado={abrirModalResultado}
               />
             ))}
           </div>
@@ -458,6 +528,75 @@ function MonitoramentoContent() {
           )}
         </>
       )}
+
+      <Dialog open={resultadoModalOpen} onOpenChange={(open) => !open && setResultadoModalOpen(false)}>
+        {resultadoPregao && (
+          <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle>Registrar resultado</DialogTitle>
+              <DialogDescription>
+                {resultadoPregao.numeroPregao} • {resultadoPregao.portal}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Resultado</Label>
+                <Select value={resultadoStatus} onValueChange={setResultadoStatus}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="PENDENTE">Pendente</SelectItem>
+                    <SelectItem value="GANHOU">Ganhou</SelectItem>
+                    <SelectItem value="PERDEU">Perdeu</SelectItem>
+                    <SelectItem value="DESISTIU">Desistiu</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Fonte do valor de referência</Label>
+                <Select value={resultadoFonte || "EMPTY"} onValueChange={(v) => setResultadoFonte(v === "EMPTY" ? "" : v)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Opcional" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="EMPTY">Não informar</SelectItem>
+                    <SelectItem value="PNCP">PNCP</SelectItem>
+                    <SelectItem value="EDITAL">Edital</SelectItem>
+                    <SelectItem value="MANUAL">Manual</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Valor de referência</Label>
+                <Input inputMode="decimal" value={resultadoValorReferencia} onChange={(e) => setResultadoValorReferencia(e.target.value)} />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Valor final</Label>
+                <Input inputMode="decimal" value={resultadoValorFinal} onChange={(e) => setResultadoValorFinal(e.target.value)} />
+              </div>
+
+              <div className="sm:col-span-2 space-y-1.5">
+                <Label>Observação</Label>
+                <Input value={resultadoObs} onChange={(e) => setResultadoObs(e.target.value)} placeholder="Opcional" />
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setResultadoModalOpen(false)} disabled={salvandoResultado}>
+                Cancelar
+              </Button>
+              <Button onClick={salvarResultado} disabled={salvandoResultado}>
+                {salvandoResultado ? "Salvando..." : "Salvar"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
     </div>
   )
 }

--- a/apps/web/src/app/negocios/pregoes/page.tsx
+++ b/apps/web/src/app/negocios/pregoes/page.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Layout } from "@/components/layout";
+import { AuthGuard } from "@/components/AuthGuard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Badge } from "@/components/ui/Badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import {
+  exportarResultadosPregoesCsv,
+  listarResultadosPregoes,
+  metricasPregoes,
+  registrarResultadoPregao,
+  type FonteValorReferenciaPregao,
+  type PregaoCentralItem,
+  type ResultadoPregao,
+} from "@/lib/api";
+import { Download, Filter, Gavel, Loader2, Save, Search } from "lucide-react";
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+
+const money = new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" });
+
+function formatarDataHora(s?: string | null) {
+  if (!s) return "-";
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return "-";
+  return format(d, "dd/MM/yyyy 'às' HH:mm", { locale: ptBR });
+}
+
+function badgeResultado(r?: string | null) {
+  const res = (r ?? "PENDENTE").toString();
+  if (res === "GANHOU") return <Badge variant="default">Ganhou</Badge>;
+  if (res === "PERDEU") return <Badge variant="secondary">Perdeu</Badge>;
+  if (res === "DESISTIU") return <Badge variant="outline">Desistiu</Badge>;
+  return <Badge variant="outline">Pendente</Badge>;
+}
+
+type Filtros = {
+  portal: string;
+  resultado: ResultadoPregao | "ALL";
+  periodoPor: "INICIO" | "FINALIZACAO";
+  dataInicio: string;
+  dataFim: string;
+  licitacao: string;
+};
+
+type ModalState = {
+  open: boolean;
+  pregao?: PregaoCentralItem | null;
+};
+
+export default function CentralPregoesPage() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [filtros, setFiltros] = useState<Filtros>({
+    portal: "ALL",
+    resultado: "ALL",
+    periodoPor: "INICIO",
+    dataInicio: "",
+    dataFim: "",
+    licitacao: "",
+  });
+  const [page, setPage] = useState(1);
+  const limit = 12;
+
+  const [modal, setModal] = useState<ModalState>({ open: false, pregao: null });
+  const [formResultado, setFormResultado] = useState<ResultadoPregao>("PENDENTE");
+  const [formValorFinal, setFormValorFinal] = useState<string>("");
+  const [formValorReferencia, setFormValorReferencia] = useState<string>("");
+  const [formFonte, setFormFonte] = useState<FonteValorReferenciaPregao | "">("");
+  const [formObs, setFormObs] = useState<string>("");
+
+  const queryParams = useMemo(() => {
+    return {
+      portal: filtros.portal !== "ALL" ? filtros.portal : undefined,
+      resultado: filtros.resultado !== "ALL" ? filtros.resultado : undefined,
+      periodoPor: filtros.periodoPor,
+      dataInicio: filtros.dataInicio || undefined,
+      dataFim: filtros.dataFim || undefined,
+      licitacao: filtros.licitacao || undefined,
+      page,
+      limit,
+    };
+  }, [filtros, page]);
+
+  const { data: listResp, isLoading: loadingList } = useQuery({
+    queryKey: ["central-pregoes", queryParams],
+    queryFn: () => listarResultadosPregoes(queryParams),
+  });
+
+  const { data: metricas } = useQuery({
+    queryKey: ["central-pregoes-metricas", queryParams.portal, queryParams.resultado, queryParams.dataInicio, queryParams.dataFim, queryParams.licitacao],
+    queryFn: () =>
+      metricasPregoes({
+        portal: queryParams.portal,
+        resultado: queryParams.resultado as ResultadoPregao | undefined,
+        periodoPor: queryParams.periodoPor,
+        dataInicio: queryParams.dataInicio,
+        dataFim: queryParams.dataFim,
+        licitacao: queryParams.licitacao,
+      }),
+  });
+
+  const items = listResp?.items ?? [];
+  const total = listResp?.total ?? 0;
+  const totalPages = Math.max(Math.ceil(total / limit), 1);
+
+  const salvarMutation = useMutation({
+    mutationFn: async () => {
+      if (!modal.pregao?.id) throw new Error("Pregão inválido.");
+      const valorFinal = formValorFinal.trim() ? Number(formValorFinal.replace(",", ".")) : null;
+      const valorReferencia = formValorReferencia.trim() ? Number(formValorReferencia.replace(",", ".")) : null;
+      if (valorFinal != null && (Number.isNaN(valorFinal) || valorFinal < 0)) throw new Error("Valor final inválido.");
+      if (valorReferencia != null && (Number.isNaN(valorReferencia) || valorReferencia < 0)) throw new Error("Valor de referência inválido.");
+
+      return registrarResultadoPregao(modal.pregao.id, {
+        resultado: formResultado,
+        valorFinal,
+        valorReferencia,
+        fonteValorReferencia: formFonte || null,
+        observacao: formObs?.trim() || null,
+      });
+    },
+    onSuccess: () => {
+      toast({ title: "Resultado registrado", description: "Os dados foram salvos com sucesso." });
+      setModal({ open: false, pregao: null });
+      queryClient.invalidateQueries({ queryKey: ["central-pregoes"] });
+      queryClient.invalidateQueries({ queryKey: ["central-pregoes-metricas"] });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Erro ao salvar",
+        description: error?.response?.data?.message || error?.message || "Não foi possível registrar o resultado.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      const { blob, fileName } = await exportarResultadosPregoesCsv({
+        portal: queryParams.portal,
+        resultado: queryParams.resultado as ResultadoPregao | undefined,
+        periodoPor: queryParams.periodoPor,
+        dataInicio: queryParams.dataInicio,
+        dataFim: queryParams.dataFim,
+        licitacao: queryParams.licitacao,
+      });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", fileName);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Falha ao exportar",
+        description: error?.response?.data?.message || error?.message || "Não foi possível exportar o CSV.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  function abrirModal(p: PregaoCentralItem) {
+    setModal({ open: true, pregao: p });
+    setFormResultado((p.resultado as ResultadoPregao) || "PENDENTE");
+    setFormValorFinal(p.valorFinal != null ? String(p.valorFinal) : "");
+    setFormValorReferencia(p.valorReferencia != null ? String(p.valorReferencia) : "");
+    setFormFonte((p.fonteValorReferencia as FonteValorReferenciaPregao) || "");
+    setFormObs(p.observacao || "");
+  }
+
+  const economiaLinha = useMemo(() => {
+    if (!modal.pregao) return null;
+    const ref = formValorReferencia.trim() ? Number(formValorReferencia.replace(",", ".")) : null;
+    const fin = formValorFinal.trim() ? Number(formValorFinal.replace(",", ".")) : null;
+    if (ref == null || fin == null || Number.isNaN(ref) || Number.isNaN(fin)) return null;
+    return ref - fin;
+  }, [modal.pregao, formValorReferencia, formValorFinal]);
+
+  return (
+    <AuthGuard>
+      <Layout fullWidth>
+        <div className="space-y-5">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <h1 className="text-2xl font-bold flex items-center gap-2 text-gray-900 dark:text-gray-100">
+                <Gavel className="w-6 h-6 text-blue-600" />
+                Central de Pregões
+              </h1>
+              <p className="text-gray-500 dark:text-gray-400 mt-1">
+                Registre resultados e acompanhe métricas com base em valor de referência.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => exportMutation.mutate()}
+              disabled={exportMutation.isPending}
+              className="gap-2"
+            >
+              {exportMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+              Exportar CSV
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm text-muted-foreground">Total</CardTitle>
+              </CardHeader>
+              <CardContent className="text-2xl font-bold">{metricas?.total ?? "-"}</CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm text-muted-foreground">Finalizados</CardTitle>
+              </CardHeader>
+              <CardContent className="text-2xl font-bold">{metricas?.totalFinalizados ?? "-"}</CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm text-muted-foreground">Economia total</CardTitle>
+              </CardHeader>
+              <CardContent className="text-2xl font-bold">
+                {typeof metricas?.economiaTotal === "number" ? money.format(metricas.economiaTotal) : "-"}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm text-muted-foreground">Base de cálculo</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground">
+                {metricas?.baseEconomia?.totalComValores ?? 0} pregão(ões) com valores
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Filter className="h-4 w-4" />
+                Filtros
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
+              <div className="space-y-1.5">
+                <Label>Portal</Label>
+                <Select value={filtros.portal} onValueChange={(v) => { setFiltros((s) => ({ ...s, portal: v })); setPage(1); }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ALL">Todos</SelectItem>
+                    <SelectItem value="PNCP">PNCP</SelectItem>
+                    <SelectItem value="BNC">BNC</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Resultado</Label>
+                <Select value={filtros.resultado} onValueChange={(v) => { setFiltros((s) => ({ ...s, resultado: v as any })); setPage(1); }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ALL">Todos</SelectItem>
+                    <SelectItem value="PENDENTE">Pendente</SelectItem>
+                    <SelectItem value="GANHOU">Ganhou</SelectItem>
+                    <SelectItem value="PERDEU">Perdeu</SelectItem>
+                    <SelectItem value="DESISTIU">Desistiu</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Filtrar período por</Label>
+                <Select value={filtros.periodoPor} onValueChange={(v) => { setFiltros((s) => ({ ...s, periodoPor: v as any })); setPage(1); }}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="INICIO">Início do pregão</SelectItem>
+                    <SelectItem value="FINALIZACAO">Finalização (registro do resultado)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Data início</Label>
+                <Input
+                  type="date"
+                  value={filtros.dataInicio}
+                  onChange={(e) => { setFiltros((s) => ({ ...s, dataInicio: e.target.value })); setPage(1); }}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Data fim</Label>
+                <Input
+                  type="date"
+                  value={filtros.dataFim}
+                  onChange={(e) => { setFiltros((s) => ({ ...s, dataFim: e.target.value })); setPage(1); }}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Licitação / busca</Label>
+                <div className="relative">
+                  <Search className="w-4 h-4 absolute left-3 top-3 text-gray-400" />
+                  <Input
+                    value={filtros.licitacao}
+                    onChange={(e) => { setFiltros((s) => ({ ...s, licitacao: e.target.value })); setPage(1); }}
+                    placeholder="Número, órgão, objeto..."
+                    className="pl-9"
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            {loadingList ? (
+              <div className="col-span-full flex items-center justify-center py-14">
+                <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
+              </div>
+            ) : items.length === 0 ? (
+              <div className="col-span-full rounded-xl border border-gray-100 bg-white p-8 text-center text-sm text-muted-foreground dark:border-gray-800 dark:bg-gray-900">
+                Nenhum pregão encontrado com os filtros atuais.
+              </div>
+            ) : (
+              items.map((p) => {
+                const econ =
+                  typeof p.valorReferencia === "number" && typeof p.valorFinal === "number"
+                    ? p.valorReferencia - p.valorFinal
+                    : null;
+                return (
+                  <Card key={p.id}>
+                    <CardHeader className="pb-2">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <CardTitle className="text-base truncate">
+                            {p.numeroPregao} • {p.portal}
+                          </CardTitle>
+                          <p className="text-xs text-muted-foreground truncate">
+                            {p.bid?.title ? `Licitação: ${p.bid.title}` : "Sem licitação vinculada"}
+                          </p>
+                        </div>
+                        <div className="shrink-0">{badgeResultado(p.resultado || "PENDENTE")}</div>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                      <div className="text-sm text-gray-800 dark:text-gray-100 line-clamp-2">{p.objeto}</div>
+                      <div className="text-xs text-muted-foreground">
+                        <div><span className="font-medium">Órgão:</span> {p.orgao || "-"}</div>
+                        <div><span className="font-medium">Início:</span> {formatarDataHora(p.horarioInicio)}</div>
+                        <div><span className="font-medium">Finalizado:</span> {formatarDataHora(p.finalizadoEm)}</div>
+                      </div>
+                      <div className="grid grid-cols-3 gap-2 text-xs">
+                        <div className="rounded-lg border p-2">
+                          <div className="text-muted-foreground">Ref.</div>
+                          <div className="font-semibold">{typeof p.valorReferencia === "number" ? money.format(p.valorReferencia) : "-"}</div>
+                        </div>
+                        <div className="rounded-lg border p-2">
+                          <div className="text-muted-foreground">Final</div>
+                          <div className="font-semibold">{typeof p.valorFinal === "number" ? money.format(p.valorFinal) : "-"}</div>
+                        </div>
+                        <div className="rounded-lg border p-2">
+                          <div className="text-muted-foreground">Economia</div>
+                          <div className="font-semibold">{typeof econ === "number" ? money.format(econ) : "-"}</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-end">
+                        <Button type="button" size="sm" onClick={() => abrirModal(p)} className="gap-2">
+                          <Save className="h-4 w-4" />
+                          Registrar resultado
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })
+            )}
+          </div>
+
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              Página {page} de {totalPages} • {total} registro(s)
+            </p>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(p - 1, 1))} disabled={page <= 1}>
+                Anterior
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.min(p + 1, totalPages))} disabled={page >= totalPages}>
+                Próxima
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <Dialog open={modal.open} onOpenChange={(open) => !open && setModal({ open: false, pregao: null })}>
+          {modal.pregao && (
+            <DialogContent className="sm:max-w-lg">
+              <DialogHeader>
+                <DialogTitle>Registrar resultado</DialogTitle>
+                <DialogDescription>
+                  {modal.pregao.numeroPregao} • {modal.pregao.portal}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Resultado</Label>
+                  <Select value={formResultado} onValueChange={(v) => setFormResultado(v as ResultadoPregao)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="PENDENTE">Pendente</SelectItem>
+                      <SelectItem value="GANHOU">Ganhou</SelectItem>
+                      <SelectItem value="PERDEU">Perdeu</SelectItem>
+                      <SelectItem value="DESISTIU">Desistiu</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label>Fonte do valor de referência</Label>
+                  <Select value={formFonte || "EMPTY"} onValueChange={(v) => setFormFonte(v === "EMPTY" ? "" : (v as any))}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Opcional" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="EMPTY">Não informar</SelectItem>
+                      <SelectItem value="PNCP">PNCP</SelectItem>
+                      <SelectItem value="EDITAL">Edital</SelectItem>
+                      <SelectItem value="MANUAL">Manual</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label>Valor de referência</Label>
+                  <Input inputMode="decimal" value={formValorReferencia} onChange={(e) => setFormValorReferencia(e.target.value)} placeholder="Ex: 10000" />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label>Valor final</Label>
+                  <Input inputMode="decimal" value={formValorFinal} onChange={(e) => setFormValorFinal(e.target.value)} placeholder="Ex: 9500" />
+                </div>
+
+                <div className="sm:col-span-2 space-y-1.5">
+                  <Label>Observação</Label>
+                  <Input value={formObs} onChange={(e) => setFormObs(e.target.value)} placeholder="Opcional" />
+                </div>
+              </div>
+
+              <div className="text-xs text-muted-foreground">
+                {typeof economiaLinha === "number" ? (
+                  <>Economia calculada: <span className="font-semibold text-gray-800 dark:text-gray-100">{money.format(economiaLinha)}</span></>
+                ) : (
+                  <>Informe valor de referência e valor final para calcular a economia.</>
+                )}
+              </div>
+
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setModal({ open: false, pregao: null })} disabled={salvarMutation.isPending}>
+                  Cancelar
+                </Button>
+                <Button onClick={() => salvarMutation.mutate()} disabled={salvarMutation.isPending} className="gap-2">
+                  {salvarMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                  Salvar
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          )}
+        </Dialog>
+      </Layout>
+    </AuthGuard>
+  );
+}
+

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -66,6 +66,7 @@ const navGroups: NavGroup[] = [
                 subItems: [
                     { label: "Funil de licitações (Kanban)", href: "/negocios/funil", icon: TrendingUp },
                     { label: "Agenda", href: "/negocios/agenda", icon: CalendarDays },
+                    { label: "Pregões (Central)", href: "/negocios/pregoes", icon: Gavel },
                     { label: "Monitoramento", href: "/monitoramento", icon: Radio },
                 ]
             },

--- a/apps/web/src/components/monitoramento/CardPregao.tsx
+++ b/apps/web/src/components/monitoramento/CardPregao.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
-import { ExternalLink, Clock, TrendingDown, Plus } from 'lucide-react'
+import { ExternalLink, Clock, TrendingDown, Plus, ClipboardEdit } from 'lucide-react'
 
 export interface PregaoMonitorado {
   id?: string
@@ -14,12 +14,14 @@ export interface PregaoMonitorado {
   urlSalaDisputa: string
   urlFallbackPncp?: string
   melhorLance?: number
+  resultado?: string
 }
 
 interface CardPregaoProps {
   pregao: PregaoMonitorado
   onCriarLicitacao?: (pregao: PregaoMonitorado) => void
   criandoLicitacao?: boolean
+  onRegistrarResultado?: (pregao: PregaoMonitorado) => void
 }
 
 const CORES_PORTAL: Record<string, string> = {
@@ -66,7 +68,7 @@ function useCountdown(horario: string) {
   return { texto, ref }
 }
 
-export function CardPregao({ pregao, onCriarLicitacao, criandoLicitacao }: CardPregaoProps) {
+export function CardPregao({ pregao, onCriarLicitacao, criandoLicitacao, onRegistrarResultado }: CardPregaoProps) {
   const { texto: countdown, ref: cardRef } = useCountdown(pregao.horarioInicio)
 
   const temUrlPortal = pregao.urlSalaDisputa &&
@@ -138,6 +140,22 @@ export function CardPregao({ pregao, onCriarLicitacao, criandoLicitacao }: CardP
           </button>
           <span className="text-[11px] text-muted-foreground">
             Pré-preenche os dados automaticamente
+          </span>
+        </div>
+      )}
+
+      {onRegistrarResultado && pregao.id && (
+        <div className="flex items-center justify-between pt-1 border-t border-border">
+          <button
+            type="button"
+            onClick={() => onRegistrarResultado(pregao)}
+            className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:border-primary transition-colors flex items-center gap-1"
+            title="Registrar resultado deste pregão"
+          >
+            <ClipboardEdit className="h-3 w-3" /> Registrar resultado
+          </button>
+          <span className="text-[11px] text-muted-foreground">
+            Vai para a Central de Pregões
           </span>
         </div>
       )}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -638,6 +638,96 @@ export async function vincularPregaoMonitorado(pregaoId: string, bidId: string):
   return res
 }
 
+export type ResultadoPregao = "GANHOU" | "PERDEU" | "DESISTIU" | "PENDENTE"
+export type FonteValorReferenciaPregao = "PNCP" | "EDITAL" | "MANUAL"
+
+export interface PregaoCentralItem {
+  id: string
+  bidId?: string | null
+  bid?: { id: string; title?: string | null; agency?: string | null } | null
+  portal: string
+  status: string
+  numeroPregao: string
+  objeto: string
+  orgao?: string | null
+  horarioInicio: string
+  urlSalaDisputa: string
+  melhorLance?: number | null
+  resultado?: ResultadoPregao
+  valorFinal?: number | null
+  valorReferencia?: number | null
+  fonteValorReferencia?: FonteValorReferenciaPregao | null
+  observacao?: string | null
+  finalizadoEm?: string | null
+}
+
+export async function listarResultadosPregoes(params?: {
+  portal?: string
+  resultado?: ResultadoPregao
+  periodoPor?: "INICIO" | "FINALIZACAO"
+  dataInicio?: string
+  dataFim?: string
+  licitacao?: string
+  page?: number
+  limit?: number
+}): Promise<{ page: number; limit: number; total: number; items: PregaoCentralItem[] }> {
+  const { data } = await api.get("/monitoramento/pregoes/resultados", { params })
+  return data
+}
+
+export async function metricasPregoes(params?: {
+  portal?: string
+  resultado?: ResultadoPregao
+  periodoPor?: "INICIO" | "FINALIZACAO"
+  dataInicio?: string
+  dataFim?: string
+  licitacao?: string
+}): Promise<{
+  total: number
+  totalFinalizados: number
+  totalComValorReferencia: number
+  porResultado: Record<string, number>
+  economiaTotal: number
+  baseEconomia: { totalComValores: number; somaValorReferencia: number; somaValorFinal: number }
+}> {
+  const { data } = await api.get("/monitoramento/pregoes/metricas", { params })
+  return data
+}
+
+export async function registrarResultadoPregao(
+  pregaoId: string,
+  body: {
+    resultado: ResultadoPregao
+    valorFinal?: number | null
+    valorReferencia?: number | null
+    fonteValorReferencia?: FonteValorReferenciaPregao | null
+    observacao?: string | null
+  },
+): Promise<any> {
+  const { data } = await api.patch(`/monitoramento/pregoes/${pregaoId}/resultado`, body)
+  return data
+}
+
+export async function exportarResultadosPregoesCsv(params?: {
+  portal?: string
+  resultado?: ResultadoPregao
+  periodoPor?: "INICIO" | "FINALIZACAO"
+  dataInicio?: string
+  dataFim?: string
+  licitacao?: string
+}): Promise<{ blob: Blob; fileName: string }> {
+  const response = await api.get("/monitoramento/pregoes/exportar-csv", {
+    params,
+    responseType: "blob",
+  })
+
+  const header = response.headers["content-disposition"] as string | undefined
+  const match = header?.match(/filename="([^"]+)"/)
+  const fileName = match?.[1] || `pregoes_${new Date().toISOString().slice(0, 10)}.csv`
+  const blob = new Blob([response.data], { type: "text/csv;charset=utf-8" })
+  return { blob, fileName }
+}
+
 
 // --- Checklist Items (Adicional) ---
 export async function updateChecklistItem(id: string, body: { titulo?: string; descricao?: string; exigeEvidencia?: boolean }) {


### PR DESCRIPTION
Adiciona campos/enum no PregaoMonitorado para resultado, valores e referência, com endpoints de listagem, métricas e export CSV. Cria UI /negocios/pregoes com filtros (incluindo período por início/finalização), modal de registro e atalho no monitoramento.
