### PR TITLE
feat(onboarding): F28-01 onboarding guiado + fix schemas e endpoints de empresa

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -78,6 +78,7 @@ export class AuthService {
       empresaId: user.empresaId,
       createdAt: user.createdAt.toISOString(),
       updatedAt: user.updatedAt.toISOString(),
+      onboardingConcluido: user.onboardingConcluido,
     };
 
     // Gerar token JWT

--- a/apps/api/src/empresa/empresa.controller.ts
+++ b/apps/api/src/empresa/empresa.controller.ts
@@ -56,6 +56,26 @@ export class EmpresaController {
   }
 
   /**
+   * Atualiza dados da empresa do usuário autenticado (nome e/ou segmento)
+   * PATCH /empresas/me
+   */
+  @Patch("me")
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  async updateMyEmpresa(
+    @Tenant() empresaId: string,
+    @Body() body: { nome?: string; segmento?: string },
+  ): Promise<Empresa> {
+    if (body.nome !== undefined && body.nome.trim().length < 2) {
+      throw new BadRequestException("Nome da empresa deve ter pelo menos 2 caracteres.");
+    }
+    if (body.nome === undefined && body.segmento === undefined) {
+      throw new BadRequestException("Informe ao menos um campo para atualizar.");
+    }
+    return this.empresaService.atualizarDados(empresaId, body);
+  }
+
+  /**
    * Busca a configuração de alerta de pregão
    * GET /empresas/configuracoes/alertas
    */

--- a/apps/api/src/empresa/empresa.service.ts
+++ b/apps/api/src/empresa/empresa.service.ts
@@ -37,12 +37,26 @@ export class EmpresaService {
       throw new NotFoundException(`Empresa não encontrada`);
     }
 
-    return {
-      id: empresa.id,
-      name: empresa.name,
-      createdAt: empresa.createdAt.toISOString(),
-      updatedAt: empresa.updatedAt.toISOString(),
-    };
+    return this.mapToEmpresa(empresa);
+  }
+
+  /**
+   * Atualiza dados da empresa do usuário autenticado (nome e/ou segmento)
+   */
+  async atualizarDados(
+    empresaId: string,
+    dados: { nome?: string; segmento?: string },
+  ): Promise<Empresa> {
+    const updateData: { name?: string; segmento?: string } = {};
+    if (dados.nome !== undefined) updateData.name = dados.nome.trim();
+    if (dados.segmento !== undefined) updateData.segmento = dados.segmento;
+
+    const empresa = await this.prisma.empresa.update({
+      where: { id: empresaId },
+      data: updateData,
+    });
+
+    return this.mapToEmpresa(empresa);
   }
 
   /**
@@ -63,12 +77,7 @@ export class EmpresaService {
       throw new NotFoundException(`Empresa com ID ${id} não encontrada`);
     }
 
-    return {
-      id: empresa.id,
-      name: empresa.name,
-      createdAt: empresa.createdAt.toISOString(),
-      updatedAt: empresa.updatedAt.toISOString(),
-    };
+    return this.mapToEmpresa(empresa);
   }
 
   /**
@@ -99,5 +108,21 @@ export class EmpresaService {
       select: { minutosAlertaPregao: true },
     });
     return { minutosAlertaPregao: empresa.minutosAlertaPregao };
+  }
+
+  private mapToEmpresa(empresa: {
+    id: string;
+    name: string;
+    segmento: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): Empresa {
+    return {
+      id: empresa.id,
+      name: empresa.name,
+      segmento: empresa.segmento,
+      createdAt: empresa.createdAt.toISOString(),
+      updatedAt: empresa.updatedAt.toISOString(),
+    };
   }
 }

--- a/apps/web/src/contexts/auth-context.tsx
+++ b/apps/web/src/contexts/auth-context.tsx
@@ -11,6 +11,7 @@ interface AuthContextType {
     login: (token: string, user: User) => void;
     logout: () => void;
     isLoading: boolean;
+    markOnboardingComplete: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -48,8 +49,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         router.push("/login");
     };
 
+    const markOnboardingComplete = () => {
+        if (!user) return;
+        const updatedUser: User = { ...user, onboardingConcluido: true };
+        setUser(updatedUser);
+        if (token) setAuth(token, updatedUser);
+    };
+
     return (
-        <AuthContext.Provider value={{ user, token, login, logout, isLoading }}>
+        <AuthContext.Provider value={{ user, token, login, logout, isLoading, markOnboardingComplete }}>
             {children}
         </AuthContext.Provider>
     );

--- a/packages/shared/src/schemas/empresa.ts
+++ b/packages/shared/src/schemas/empresa.ts
@@ -13,6 +13,7 @@ export const createEmpresaSchema = z.object({
 export const empresaSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
+  segmento: z.string().nullable().optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -31,6 +31,7 @@ export const userSchema = z.object({
   empresaId: z.string().uuid(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  onboardingConcluido: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Onboarding guiado com tour de 9 passos cobrindo todas as features do sistema
- Campo `onboardingConcluido` no banco (User) e no schema compartilhado
- Campo `segmento` no banco (Empresa) e no schema compartilhado
- Endpoint `PATCH /empresas/me` para atualizar nome e segmento
- `markOnboardingComplete` no AuthContext para persistir estado no frontend
- Fix do erro de build: schemas do `@licitafacil/shared` não estavam commitados

## Migrations incluídas

- `add_onboarding_concluido_user` — `onboardingConcluido BOOLEAN DEFAULT false` na tabela `users`
- `add_segmento_empresa` — `segmento TEXT` na tabela `empresas`

## Test plan

- [ ] Testar fluxo completo do onboarding em novo usuário
- [ ] Verificar que o tour não reaparece após F5 (estado persistido no banco)
- [ ] Testar `PATCH /empresas/me` com nome e segmento
- [ ] Confirmar que o build do deploy passa sem erros de TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)