### PR TITLE
feat(billing): PL-01 — Motor de Acesso por Plano (Backend Guard)

### DIFF
--- a/apps/api/src/analise/analise-concorrentes.controller.ts
+++ b/apps/api/src/analise/analise-concorrentes.controller.ts
@@ -6,9 +6,12 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { FeatureAccessGuard } from "../common/guards/feature-access.guard";
+import { RequireFeature } from "../common/decorators/require-feature.decorator";
 import { AnaliseConcorrentesService } from "./analise-concorrentes.service";
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, FeatureAccessGuard)
+@RequireFeature("analytics_concorrencia")
 @Controller("analise")
 export class AnaliseConcorrentesController {
   constructor(

--- a/apps/api/src/bid/bid.controller.ts
+++ b/apps/api/src/bid/bid.controller.ts
@@ -27,8 +27,10 @@ import { DocumentService } from "../document/document.service";
 import { SoftDeleteService } from "../common/services/soft-delete.service";
 import { AuditLogService } from "../audit-log/audit-log.service";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { FeatureAccessGuard } from "../common/guards/feature-access.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
 import { Roles } from "../common/decorators/roles.decorator";
+import { RequireFeature } from "../common/decorators/require-feature.decorator";
 import { Tenant } from "../common/decorators/tenant.decorator";
 import { CurrentUser } from "../auth/decorators/current-user.decorator";
 import { Audit } from "../audit-log/decorators/audit.decorator";
@@ -582,6 +584,8 @@ export class BidController {
   @Post(":id/analisar-edital")
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  @UseGuards(FeatureAccessGuard)
+  @RequireFeature("ia_analise_edital")
   @UseInterceptors(FileInterceptor("pdf"))
   async analisarEdital(
     @Param("id") id: string,
@@ -637,7 +641,8 @@ export class BidController {
   }
 
   @Post(":id/chat")
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(FeatureAccessGuard)
+  @RequireFeature("ia_chat_edital")
   @HttpCode(HttpStatus.OK)
   @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
   async chat(
@@ -654,7 +659,8 @@ export class BidController {
   }
 
   @Get(":id/chat/historico")
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(FeatureAccessGuard)
+  @RequireFeature("ia_chat_edital")
   @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
   async chatHistorico(
     @Param("id") id: string,
@@ -669,6 +675,8 @@ export class BidController {
   }
 
   @Post(":id/importar-documentos-analise")
+  @UseGuards(FeatureAccessGuard)
+  @RequireFeature("ia_analise_edital")
   @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
   @Audit({ action: "bid.import_documents", resourceType: "Bid" })
   async importarDocumentosAnalise(
@@ -680,6 +688,8 @@ export class BidController {
   }
 
   @Post(":id/gerar-checklist-analise")
+  @UseGuards(FeatureAccessGuard)
+  @RequireFeature("ia_analise_edital")
   @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
   @Audit({ action: "bid.generate_checklist", resourceType: "Bid" })
   async gerarChecklistAnalise(

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -1,16 +1,17 @@
 import { Global, Module } from "@nestjs/common";
 import { SoftDeleteService } from "./services/soft-delete.service";
 import { AuditLogModule } from "../audit-log/audit-log.module";
+import { FeatureAccessGuard } from "./guards/feature-access.guard";
 
 /**
  * Módulo comum para serviços compartilhados
- * 
+ *
  * @Global() - Disponibiliza serviços em todos os módulos sem precisar importar
  */
 @Global()
 @Module({
   imports: [AuditLogModule], // SoftDeleteService depende do AuditLogService
-  providers: [SoftDeleteService],
-  exports: [SoftDeleteService],
+  providers: [SoftDeleteService, FeatureAccessGuard],
+  exports: [SoftDeleteService, FeatureAccessGuard],
 })
 export class CommonModule {}

--- a/apps/api/src/common/constants/feature-matrix.ts
+++ b/apps/api/src/common/constants/feature-matrix.ts
@@ -1,0 +1,40 @@
+import { PlanoTipo } from "@prisma/client";
+
+export type FeatureName =
+  | "monitoramento"
+  | "ia_analise_edital"
+  | "ia_chat_edital"
+  | "disputa_ao_vivo"
+  | "analytics_concorrencia"
+  | "modulo_juridico";
+
+export const FEATURE_MATRIX: Record<FeatureName, PlanoTipo[]> = {
+  monitoramento: [PlanoTipo.PROFESSIONAL, PlanoTipo.ENTERPRISE],
+  ia_analise_edital: [PlanoTipo.PROFESSIONAL, PlanoTipo.ENTERPRISE],
+  ia_chat_edital: [PlanoTipo.PROFESSIONAL, PlanoTipo.ENTERPRISE],
+  disputa_ao_vivo: [PlanoTipo.PROFESSIONAL, PlanoTipo.ENTERPRISE],
+  analytics_concorrencia: [PlanoTipo.ENTERPRISE],
+  modulo_juridico: [PlanoTipo.ENTERPRISE],
+};
+
+export const USER_LIMITS: Record<PlanoTipo, number | null> = {
+  [PlanoTipo.STARTER]: 2,
+  [PlanoTipo.PROFESSIONAL]: 5,
+  [PlanoTipo.ENTERPRISE]: null,
+};
+
+export const PLAN_HIERARCHY: PlanoTipo[] = [
+  PlanoTipo.STARTER,
+  PlanoTipo.PROFESSIONAL,
+  PlanoTipo.ENTERPRISE,
+];
+
+export function getRequiredPlan(feature: FeatureName): PlanoTipo {
+  const allowed = FEATURE_MATRIX[feature];
+  for (const plan of PLAN_HIERARCHY) {
+    if (allowed.includes(plan)) {
+      return plan;
+    }
+  }
+  return PlanoTipo.ENTERPRISE;
+}

--- a/apps/api/src/common/decorators/require-feature.decorator.ts
+++ b/apps/api/src/common/decorators/require-feature.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from "@nestjs/common";
+import { type FeatureName } from "../constants/feature-matrix";
+
+export const FEATURE_KEY = "required_feature";
+export const RequireFeature = (feature: FeatureName) => SetMetadata(FEATURE_KEY, feature);

--- a/apps/api/src/common/guards/feature-access.guard.ts
+++ b/apps/api/src/common/guards/feature-access.guard.ts
@@ -1,0 +1,105 @@
+import {
+  Injectable,
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { ClienteStatus, PlanoTipo } from "@prisma/client";
+import { PrismaService } from "../../prisma/prisma.service";
+import { IS_PUBLIC_KEY } from "../../auth/decorators/public.decorator";
+import { FEATURE_KEY } from "../decorators/require-feature.decorator";
+import {
+  FEATURE_MATRIX,
+  type FeatureName,
+  getRequiredPlan,
+} from "../constants/feature-matrix";
+
+interface CachedCliente {
+  plano: PlanoTipo;
+  status: ClienteStatus;
+  fetchedAt: number;
+}
+
+const clienteConfigCache = new Map<string, CachedCliente>();
+const TTL_MS = 60_000;
+
+@Injectable()
+export class FeatureAccessGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
+    const feature = this.reflector.getAllAndOverride<FeatureName>(FEATURE_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!feature) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as { empresaId?: string } | undefined;
+    if (!user?.empresaId) {
+      throw new UnauthorizedException();
+    }
+
+    const empresaId = user.empresaId;
+    const { plano, status } = await this.getClientePlanAndStatus(empresaId);
+
+    if (status === ClienteStatus.SUSPENSO || status === ClienteStatus.CANCELADO) {
+      throw new ForbiddenException({
+        statusCode: 403,
+        code: "ACCOUNT_INACTIVE",
+        message: "Sua conta está suspensa ou cancelada",
+        status,
+      });
+    }
+
+    const allowed = FEATURE_MATRIX[feature];
+    if (!allowed.includes(plano)) {
+      throw new ForbiddenException({
+        statusCode: 403,
+        code: "FEATURE_LOCKED",
+        message: "Recurso não disponível no seu plano atual",
+        currentPlan: plano,
+        requiredPlan: getRequiredPlan(feature),
+        feature,
+      });
+    }
+
+    return true;
+  }
+
+  private async getClientePlanAndStatus(
+    empresaId: string,
+  ): Promise<{ plano: PlanoTipo; status: ClienteStatus }> {
+    const now = Date.now();
+    const cached = clienteConfigCache.get(empresaId);
+    if (cached && now - cached.fetchedAt <= TTL_MS) {
+      return { plano: cached.plano, status: cached.status };
+    }
+
+    const config = await this.prisma.clienteConfig.findFirst({
+      where: { empresaId, deletedAt: null },
+    });
+
+    const plano = config?.plano ?? PlanoTipo.STARTER;
+    const status = config?.status ?? ClienteStatus.ATIVO;
+
+    clienteConfigCache.set(empresaId, { plano, status, fetchedAt: now });
+
+    return { plano, status };
+  }
+}

--- a/apps/api/src/disputa/disputa.controller.ts
+++ b/apps/api/src/disputa/disputa.controller.ts
@@ -13,6 +13,8 @@ import {
 } from "@nestjs/common";
 import { type User } from "@licitafacil/shared";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { FeatureAccessGuard } from "../common/guards/feature-access.guard";
+import { RequireFeature } from "../common/decorators/require-feature.decorator";
 import { CurrentUser } from "../auth/decorators/current-user.decorator";
 import { Tenant } from "../common/decorators/tenant.decorator";
 import { CreateDisputaDto } from "./dto/create-disputa.dto";
@@ -24,7 +26,8 @@ import { PatchResultadoDisputaDto } from "./dto/patch-resultado-disputa.dto";
 import { PostLanceDisputaDto } from "./dto/post-lance-disputa.dto";
 import type { Response } from "express";
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, FeatureAccessGuard)
+@RequireFeature("disputa_ao_vivo")
 @Controller("disputa")
 export class DisputaController {
   constructor(private readonly disputaService: DisputaService) {}

--- a/apps/api/src/juridico/juridico.controller.ts
+++ b/apps/api/src/juridico/juridico.controller.ts
@@ -20,7 +20,9 @@ import {
 } from "@prisma/client";
 import { IsArray, IsBoolean, IsEnum, IsOptional, IsString, IsUUID } from "class-validator";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { FeatureAccessGuard } from "../common/guards/feature-access.guard";
 import { TenantGuard } from "../common/guards/tenant.guard";
+import { RequireFeature } from "../common/decorators/require-feature.decorator";
 import { Tenant } from "../common/decorators/tenant.decorator";
 import { JuridicoService } from "./juridico.service";
 import { CurrentUser } from "../auth/decorators/current-user.decorator";
@@ -85,7 +87,8 @@ class AtualizarStatusPeticaoDto {
 }
 
 @Controller("juridico")
-@UseGuards(JwtAuthGuard, TenantGuard)
+@UseGuards(JwtAuthGuard, TenantGuard, FeatureAccessGuard)
+@RequireFeature("modulo_juridico")
 export class JuridicoController {
   private readonly logger = new Logger(JuridicoController.name);
 

--- a/apps/api/src/monitoramento/monitoramento.controller.ts
+++ b/apps/api/src/monitoramento/monitoramento.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Post, Patch, Delete, Param, Query, Body, Req, UseGuards, Header } from '@nestjs/common'
 import { MonitoramentoService } from './monitoramento.service'
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
+import { FeatureAccessGuard } from '../common/guards/feature-access.guard'
+import { RequireFeature } from '../common/decorators/require-feature.decorator'
 import { FiltrosPregaoDto } from './dto/filtros-pregao.dto'
 import { CadastrarPregaoDto } from './dto/cadastrar-pregao.dto'
 import { AtualizarPregaoDto } from './dto/atualizar-pregao.dto'
@@ -8,7 +10,8 @@ import { RegistrarResultadoPregaoDto } from './dto/registrar-resultado-pregao.dt
 import { FiltrosCentralPregoesDto } from './dto/filtros-central-pregoes.dto'
 
 @Controller('monitoramento')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, FeatureAccessGuard)
+@RequireFeature('monitoramento')
 export class MonitoramentoController {
   constructor(private service: MonitoramentoService) {}
 

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -4,12 +4,12 @@ import {
   NotFoundException,
   ForbiddenException,
 } from "@nestjs/common";
+import { PlanoTipo } from "@prisma/client";
 import { PrismaService } from "../prisma/prisma.service";
 import { PrismaTenantService } from "../prisma/prisma-tenant.service";
 import { type CreateUserInput, type User, UserRole } from "@licitafacil/shared";
 import * as bcrypt from "bcrypt";
-
-const MAX_USERS_PER_EMPRESA = 30;
+import { PLAN_HIERARCHY, USER_LIMITS } from "../common/constants/feature-matrix";
 
 @Injectable()
 export class UserService {
@@ -17,6 +17,35 @@ export class UserService {
     private readonly prisma: PrismaService,
     private readonly prismaTenant: PrismaTenantService,
   ) { }
+
+  private async assertUserLimitNotExceeded(empresaId: string): Promise<void> {
+    const clienteConfig = await this.prisma.clienteConfig.findFirst({
+      where: { empresaId, deletedAt: null },
+    });
+    const plano = clienteConfig?.plano ?? PlanoTipo.STARTER;
+
+    const currentCount = await this.prisma.user.count({
+      where: {
+        empresaId,
+        deletedAt: null,
+      },
+    });
+
+    const maxAllowed = USER_LIMITS[plano];
+    if (maxAllowed !== null && currentCount >= maxAllowed) {
+      const currentIndex = PLAN_HIERARCHY.indexOf(plano);
+      const suggestedPlan = PLAN_HIERARCHY[currentIndex + 1] ?? PlanoTipo.ENTERPRISE;
+
+      throw new ForbiddenException({
+        statusCode: 403,
+        code: "USER_LIMIT_EXCEEDED",
+        message: `Limite de ${maxAllowed} usuários atingido para o plano ${plano}`,
+        currentCount,
+        maxAllowed,
+        suggestedPlan,
+      });
+    }
+  }
 
   /**
    * Cria um novo usuário com senha hasheada
@@ -30,6 +59,8 @@ export class UserService {
     if (existingUser) {
       throw new ConflictException("Email já cadastrado");
     }
+
+    await this.assertUserLimitNotExceeded(data.empresaId);
 
     // Hash da senha
     const hashedPassword = await bcrypt.hash(data.password, 10);
@@ -149,15 +180,7 @@ export class UserService {
       );
     }
 
-    const totalUsuariosCriados = await this.prisma.user.count({
-      where: { empresaId },
-    });
-
-    if (totalUsuariosCriados >= MAX_USERS_PER_EMPRESA) {
-      throw new ForbiddenException(
-        `Limite de ${MAX_USERS_PER_EMPRESA} usuários atingido para esta empresa`,
-      );
-    }
+    await this.assertUserLimitNotExceeded(empresaId);
 
     // Verificar se email já existe
     const existingUser = await this.prisma.user.findUnique({
@@ -342,24 +365,39 @@ export class UserService {
   }
 
   /**
-   * Retorna informações de uso de usuários da empresa.
-   * Limite fixo de 30 usuários por empresa.
+   * Retorna informações de uso de usuários da empresa (ativos, sem soft-deleted),
+   * alinhado ao limite do plano em {@link USER_LIMITS}.
    */
   async obterLimite(empresaId: string) {
-    const usuariosCriados = await this.prisma.user.count({
-      where: { empresaId },
+    const clienteConfig = await this.prisma.clienteConfig.findFirst({
+      where: { empresaId, deletedAt: null },
+    });
+    const plano = clienteConfig?.plano ?? PlanoTipo.STARTER;
+
+    const usuariosAtivos = await this.prisma.user.count({
+      where: { empresaId, deletedAt: null },
     });
 
-    const percentual = Math.min(
-      Math.round((usuariosCriados / MAX_USERS_PER_EMPRESA) * 100),
-      100,
-    );
+    const limite = USER_LIMITS[plano];
+
+    if (limite === null) {
+      return {
+        atual: usuariosAtivos,
+        limite: null,
+        disponivel: null,
+        percentual: 0,
+        plano,
+      };
+    }
+
+    const percentual = Math.min(Math.round((usuariosAtivos / limite) * 100), 100);
 
     return {
-      atual: usuariosCriados,
-      limite: MAX_USERS_PER_EMPRESA,
-      disponivel: Math.max(MAX_USERS_PER_EMPRESA - usuariosCriados, 0),
+      atual: usuariosAtivos,
+      limite,
+      disponivel: Math.max(limite - usuariosAtivos, 0),
       percentual,
+      plano,
     };
   }
 


### PR DESCRIPTION
## PL-01 — Motor de Acesso por Plano

### O que foi feito
- `FeatureAccessGuard` com cache em memória (60s TTL) e `FEATURE_MATRIX`
- Decorator `@RequireFeature` para controle granular por rota/controller
- Guard aplicado em 6 controllers:
  - `monitoramento` → PROFESSIONAL+
  - `ia_analise_edital` → PROFESSIONAL+
  - `ia_chat_edital` → PROFESSIONAL+
  - `disputa_ao_vivo` → PROFESSIONAL+
  - `analytics_concorrencia` → ENTERPRISE
  - `modulo_juridico` → ENTERPRISE
- Limite de usuários por plano no `UserService`:
  - STARTER: 2 | PROFESSIONAL: 5 | ENTERPRISE: ilimitado
- 403 estruturado com `code`/`currentPlan`/`requiredPlan`/`feature` para frontend upsell (PL-02)
- Conta suspensa/cancelada → 403 com `ACCOUNT_INACTIVE`

### Validações
- `pnpm --filter @licitafacil/api typecheck` ✅
- `pnpm --filter @licitafacil/api build` ✅

### Próximo passo
PL-02 — UX de Bloqueio e Upsell (Frontend)

Closes #182
