### PR TITLE
feat(billing): PL-02 — UX de Bloqueio e Upsell

### DIFF
--- a/apps/api/src/empresa/empresa.controller.ts
+++ b/apps/api/src/empresa/empresa.controller.ts
@@ -56,6 +56,17 @@ export class EmpresaController {
   }
 
   /**
+   * Plano atual da empresa (billing) — visível a qualquer usuário do tenant.
+   * GET /empresas/me/plano
+   */
+  @Get("me/plano")
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.COLABORADOR)
+  async getMePlano(@Tenant() empresaId: string) {
+    return this.empresaService.getMePlano(empresaId);
+  }
+
+  /**
    * Atualiza dados da empresa do usuário autenticado (nome e/ou segmento)
    * PATCH /empresas/me
    */

--- a/apps/api/src/empresa/empresa.service.ts
+++ b/apps/api/src/empresa/empresa.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException, ForbiddenException } from "@nestjs/common";
+import { PlanoTipo } from "@prisma/client";
 import { PrismaService } from "../prisma/prisma.service";
 import { type CreateEmpresaInput, type Empresa } from "@licitafacil/shared";
 
@@ -38,6 +39,15 @@ export class EmpresaService {
     }
 
     return this.mapToEmpresa(empresa);
+  }
+
+  /** Plano comercial da empresa (ClienteConfig), para UI de billing no frontend. */
+  async getMePlano(empresaId: string): Promise<{ plano: PlanoTipo }> {
+    const clienteConfig = await this.prisma.clienteConfig.findFirst({
+      where: { empresaId, deletedAt: null },
+      select: { plano: true },
+    });
+    return { plano: clienteConfig?.plano ?? PlanoTipo.STARTER };
   }
 
   /**

--- a/apps/web/src/app/(authenticated)/analise/concorrentes/page.tsx
+++ b/apps/web/src/app/(authenticated)/analise/concorrentes/page.tsx
@@ -22,7 +22,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { api } from "@/lib/api";
+import { api, isBillingHandledError } from "@/lib/api";
 import { formatCurrency, formatDate, maskCNPJ } from "@/lib/utils";
 import {
   Search,
@@ -266,6 +266,9 @@ export default function AnaliseConcorrentesPage() {
       );
       setResultado(data);
     } catch (error: unknown) {
+      if (isBillingHandledError(error)) {
+        return;
+      }
       const status = (error as { response?: { status?: number } })?.response?.status;
       if (status === 404) {
         setResultado({

--- a/apps/web/src/app/(authenticated)/planos/page.tsx
+++ b/apps/web/src/app/(authenticated)/planos/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { AuthGuard } from "@/components/AuthGuard";
+import { Layout } from "@/components/layout";
+import { PLANS_DATA, PLAN_HIERARCHY, type PlanEnum } from "@/constants/plans";
+import { useAuth } from "@/contexts/auth-context";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+
+function planComparison(
+  userPlan: PlanEnum,
+  cardPlan: PlanEnum,
+): "current" | "below" | "above" {
+  const ui = PLAN_HIERARCHY.indexOf(userPlan);
+  const ci = PLAN_HIERARCHY.indexOf(cardPlan);
+  if (ci === ui) return "current";
+  if (ci < ui) return "below";
+  return "above";
+}
+
+function openUpgradeWhatsApp(planDisplayName: string) {
+  const phone = process.env.NEXT_PUBLIC_SUPPORT_WHATSAPP_PHONE ?? "5582819990000";
+  window.open(
+    `https://api.whatsapp.com/send?phone=${phone}&text=${encodeURIComponent(`Olá, tenho interesse no plano ${planDisplayName} do Limvex Licitação`)}`,
+    "_blank",
+    "noopener,noreferrer",
+  );
+}
+
+export default function PlanosPage() {
+  const { userPlan } = useAuth();
+
+  return (
+    <AuthGuard>
+      <Layout>
+        <div className="mx-auto max-w-5xl space-y-10 px-1">
+          <div className="space-y-2 text-center">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 md:text-3xl">
+              Escolha seu plano
+            </h1>
+            <p className="text-gray-500 dark:text-gray-400">
+              Selecione o plano ideal para sua operação de licitações
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {PLANS_DATA.map((plan) => {
+              const cmp = planComparison(userPlan, plan.enum);
+              const isHighlight = plan.highlighted;
+
+              return (
+                <div
+                  key={plan.enum}
+                  className={cn(
+                    "relative flex flex-col rounded-xl border bg-zinc-900 p-6",
+                    isHighlight
+                      ? "scale-[1.02] border-2 border-[#0078D1] shadow-lg shadow-black/20"
+                      : "border-zinc-800",
+                  )}
+                >
+                  {plan.badge ? (
+                    <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-[#0078D1] px-3 py-0.5 text-xs font-medium text-white">
+                      {plan.badge}
+                    </span>
+                  ) : null}
+                  {cmp === "current" ? (
+                    <span className="absolute -top-3 right-4 rounded-full bg-emerald-600/90 px-2.5 py-0.5 text-xs font-medium text-white">
+                      Seu plano
+                    </span>
+                  ) : null}
+
+                  <h2 className="text-xl font-bold text-zinc-100">{plan.name}</h2>
+                  <p className="mt-0.5 text-xs text-zinc-500">{plan.subtitle}</p>
+
+                  <div className="mt-6 border-t border-zinc-800 pt-6">
+                    <p className="text-3xl font-bold text-zinc-100">
+                      R$ {plan.priceAnnual},00
+                      <span className="text-base font-normal text-zinc-400">/mês</span>
+                    </p>
+                    <p className="mt-1 text-sm text-zinc-500">
+                      Plano anual · ou R$ {plan.priceMonthly},00/mês no semestral
+                    </p>
+                  </div>
+
+                  <ul className="mt-6 flex-1 space-y-3">
+                    {plan.features.map((f) => (
+                      <li key={f} className="flex gap-2 text-sm text-zinc-300">
+                        <Check className="h-4 w-4 shrink-0 text-[#0078D1]" aria-hidden />
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+
+                  <div className="mt-8">
+                    {cmp === "current" ? (
+                      <Button disabled className="w-full" variant="secondary">
+                        Plano atual
+                      </Button>
+                    ) : null}
+                    {cmp === "below" ? (
+                      <Button
+                        disabled
+                        variant="outline"
+                        className="w-full border-zinc-700 text-zinc-400"
+                      >
+                        Plano atual inclui
+                      </Button>
+                    ) : null}
+                    {cmp === "above" ? (
+                      <Button
+                        className="w-full bg-[#0078D1] text-white hover:bg-[#0078D1]/90"
+                        onClick={() => openUpgradeWhatsApp(plan.name)}
+                      >
+                        Falar com o suporte
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </Layout>
+    </AuthGuard>
+  );
+}

--- a/apps/web/src/app/disputa/[id]/ao-vivo/page.tsx
+++ b/apps/web/src/app/disputa/[id]/ao-vivo/page.tsx
@@ -10,7 +10,7 @@ import { HeaderDisputa } from "@/components/disputa/HeaderDisputa";
 import { PainelItem } from "@/components/disputa/PainelItem";
 import { useToast } from "@/hooks/use-toast";
 import { useDisputaSocket } from "@/hooks/useDisputaSocket";
-import { buscarDisputa } from "@/lib/api";
+import { buscarDisputa, isBillingHandledError } from "@/lib/api";
 import Link from "next/link";
 
 export default function DisputaAoVivoPage() {
@@ -18,10 +18,11 @@ export default function DisputaAoVivoPage() {
   const disputaId = id;
   const { toast } = useToast();
 
-  const { data: disputa, isLoading } = useQuery({
+  const { data: disputa, isLoading, error } = useQuery({
     queryKey: ["disputa", disputaId],
     queryFn: () => buscarDisputa(disputaId),
     enabled: Boolean(disputaId),
+    retry: (failureCount, err) => !isBillingHandledError(err) && failureCount < 1,
   });
 
   const {
@@ -56,6 +57,16 @@ export default function DisputaAoVivoPage() {
     if (!disputaId) return;
     window.postMessage({ tipo: "LVX_ATUALIZAR_DISPUTA_ATIVA", disputaId }, "*");
   }, [disputaId]);
+
+  if (error && isBillingHandledError(error)) {
+    return (
+      <AuthGuard>
+        <Layout fullWidth>
+          <div className="min-h-[50vh]" aria-hidden />
+        </Layout>
+      </AuthGuard>
+    );
+  }
 
   return (
     <AuthGuard>

--- a/apps/web/src/app/disputa/historico/[id]/page.tsx
+++ b/apps/web/src/app/disputa/historico/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
-import { api } from "@/lib/api";
+import { api, isBillingHandledError } from "@/lib/api";
 import { Download } from "lucide-react";
 import {
   ResponsiveContainer,
@@ -54,14 +54,19 @@ export default function DisputaHistoricoDetalhePage() {
   const [data, setData] = useState<HistoricoDetalheResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [downloading, setDownloading] = useState(false);
+  const [billingBlocked, setBillingBlocked] = useState(false);
 
   const load = async () => {
     setLoading(true);
     try {
       const { data } = await api.get<HistoricoDetalheResponse>(`/disputa/historico/${id}`);
       setData(data);
-    } catch {
-      toast({ title: "Erro ao carregar detalhes da disputa", variant: "destructive" });
+    } catch (e) {
+      if (isBillingHandledError(e)) {
+        setBillingBlocked(true);
+      } else {
+        toast({ title: "Erro ao carregar detalhes da disputa", variant: "destructive" });
+      }
     } finally {
       setLoading(false);
     }
@@ -92,12 +97,22 @@ export default function DisputaHistoricoDetalhePage() {
       link.click();
       link.remove();
       window.URL.revokeObjectURL(url);
-    } catch {
-      toast({ title: "Erro ao gerar PDF", variant: "destructive" });
+    } catch (e) {
+      if (!isBillingHandledError(e)) {
+        toast({ title: "Erro ao gerar PDF", variant: "destructive" });
+      }
     } finally {
       setDownloading(false);
     }
   };
+
+  if (billingBlocked) {
+    return (
+      <Layout>
+        <div className="min-h-[45vh]" aria-hidden />
+      </Layout>
+    );
+  }
 
   if (loading || !data) {
     return (

--- a/apps/web/src/app/disputa/historico/page.tsx
+++ b/apps/web/src/app/disputa/historico/page.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
-import { api } from "@/lib/api";
+import { api, isBillingHandledError } from "@/lib/api";
 import { Search } from "lucide-react";
 
 interface HistoricoDisputaResumo {
@@ -64,8 +64,10 @@ export default function DisputaHistoricoPage() {
       const { data } = await api.get<HistoricoResponse>("/disputa/historico", { params });
       setItems(data.data);
       setTotalPages(data.pagination.totalPages);
-    } catch {
-      toast({ title: "Erro ao carregar histórico de disputas", variant: "destructive" });
+    } catch (e) {
+      if (!isBillingHandledError(e)) {
+        toast({ title: "Erro ao carregar histórico de disputas", variant: "destructive" });
+      }
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/app/disputa/page.tsx
+++ b/apps/web/src/app/disputa/page.tsx
@@ -10,7 +10,7 @@ import { NovaDisputaModal } from "@/components/disputa/NovaDisputaModal";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { cancelarDisputa, listarDisputas, type Disputa } from "@/lib/api";
+import { cancelarDisputa, listarDisputas, isBillingHandledError, type Disputa } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 
 type AbaStatus = "ATIVAS" | "AGENDADAS" | "ENCERRADAS";
@@ -48,7 +48,7 @@ export default function DisputaPage() {
     queryFn: listarDisputas,
     staleTime: 8000,
     refetchInterval: 10000,
-    retry: 1,
+    retry: (failureCount, err) => !isBillingHandledError(err) && failureCount < 1,
     placeholderData: (previousData) => previousData,
     refetchIntervalInBackground: false,
   });
@@ -70,12 +70,24 @@ export default function DisputaPage() {
       await cancelarDisputa(id);
       toast({ title: "Disputa cancelada" });
       await refetch();
-    } catch {
-      toast({ title: "Falha ao cancelar disputa", variant: "destructive" });
+    } catch (e) {
+      if (!isBillingHandledError(e)) {
+        toast({ title: "Falha ao cancelar disputa", variant: "destructive" });
+      }
     } finally {
       setCancelandoId(null);
     }
   };
+
+  if (error && isBillingHandledError(error)) {
+    return (
+      <AuthGuard>
+        <Layout>
+          <div className="min-h-[45vh]" aria-hidden />
+        </Layout>
+      </AuthGuard>
+    );
+  }
 
   if (error) {
     return (

--- a/apps/web/src/app/monitoramento/page.tsx
+++ b/apps/web/src/app/monitoramento/page.tsx
@@ -4,7 +4,7 @@ import { Plus, Bell, X, Search } from 'lucide-react'
 import { CardPregao } from '@/components/monitoramento/CardPregao'
 import type { PregaoMonitorado } from '@/components/monitoramento/CardPregao'
 import { useMonitoramentoSocket } from '@/hooks/useMonitoramentoSocket'
-import { listarPregoesPncp, cadastrarPregaoMonitorado, sugerirVinculoPregao, registrarResultadoPregao } from '@/lib/api'
+import { listarPregoesPncp, cadastrarPregaoMonitorado, sugerirVinculoPregao, registrarResultadoPregao, isBillingHandledError } from '@/lib/api'
 import { useAuth } from '@/contexts/auth-context'
 import { AuthGuard } from '@/components/AuthGuard'
 import { Layout } from '@/components/layout'
@@ -98,6 +98,7 @@ function MonitoramentoContent() {
       if (pregao.uf) params.set("uf", pregao.uf)
       router.push(`/licitacoes?${params.toString()}`)
     } catch (e: any) {
+      if (isBillingHandledError(e)) return
       toast({
         title: "Falha ao preparar licitação",
         description: e?.response?.data?.message || e?.message || "Não foi possível criar o pregão monitorado para vincular.",
@@ -226,6 +227,10 @@ function MonitoramentoContent() {
       setMostrarAdicionar(false)
       carregar()
     } catch (e: any) {
+      if (isBillingHandledError(e)) {
+        setErroAdicionar('')
+        return
+      }
       setErroAdicionar(e?.message || 'Erro ao adicionar pregão')
     } finally {
       setAdicionando(false)
@@ -271,11 +276,13 @@ function MonitoramentoContent() {
       setResultadoPregao(null)
       carregar()
     } catch (e: any) {
-      toast({
-        title: "Erro ao salvar resultado",
-        description: e?.response?.data?.message || e?.message || "Não foi possível salvar.",
-        variant: "destructive",
-      })
+      if (!isBillingHandledError(e)) {
+        toast({
+          title: "Erro ao salvar resultado",
+          description: e?.response?.data?.message || e?.message || "Não foi possível salvar.",
+          variant: "destructive",
+        })
+      }
     } finally {
       setSalvandoResultado(false)
     }

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { queryClient } from "@/lib/queryClient";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from "@/contexts/auth-context";
+import { BillingProvider } from "@/contexts/billing-context";
 import { ThemeProvider } from "@/hooks/use-theme";
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -12,10 +13,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
         <ThemeProvider>
             <QueryClientProvider client={queryClient}>
                 <AuthProvider>
-                    <TooltipProvider>
-                        {children}
-                        <Toaster />
-                    </TooltipProvider>
+                    <BillingProvider>
+                        <TooltipProvider>
+                            {children}
+                            <Toaster />
+                        </TooltipProvider>
+                    </BillingProvider>
                 </AuthProvider>
             </QueryClientProvider>
         </ThemeProvider>

--- a/apps/web/src/components/billing/CanAccessFeature.tsx
+++ b/apps/web/src/components/billing/CanAccessFeature.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { hasFeatureAccess, PLAN_DISPLAY_NAMES, FEATURE_PLAN_MAP } from "@/constants/plans";
+import { useAuth } from "@/contexts/auth-context";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface Props {
+  feature: string;
+  children: ReactNode;
+  /** Se true, esconde completamente em vez de desabilitar */
+  hideIfLocked?: boolean;
+}
+
+export function CanAccessFeature({ feature, children, hideIfLocked }: Props) {
+  const { userPlan } = useAuth();
+
+  if (hasFeatureAccess(userPlan, feature)) {
+    return <>{children}</>;
+  }
+
+  if (hideIfLocked) return null;
+
+  const requiredPlan = FEATURE_PLAN_MAP[feature];
+  const planName = requiredPlan ? PLAN_DISPLAY_NAMES[requiredPlan] ?? requiredPlan : "superior";
+
+  return (
+    <Tooltip delayDuration={200}>
+      <TooltipTrigger asChild>
+        <span className="inline-flex w-full max-w-full cursor-not-allowed rounded-lg">
+          <span className="w-full opacity-50 pointer-events-none select-none">{children}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        className="max-w-[min(100vw-1rem,280px)] border-zinc-700 bg-zinc-800 text-zinc-200"
+      >
+        Disponível no plano {planName}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/billing/FeatureLockModal.tsx
+++ b/apps/web/src/components/billing/FeatureLockModal.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { AnimatePresence, motion } from "framer-motion";
+import { Lock, Users, AlertTriangle } from "lucide-react";
+import { useBilling } from "@/contexts/billing-context";
+import { PLAN_DISPLAY_NAMES, PLANS_DATA } from "@/constants/plans";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const FEATURE_DISPLAY_NAMES: Record<string, string> = {
+  monitoramento: "Monitoramento de Pregões",
+  ia_analise_edital: "Análise de Edital com IA",
+  ia_chat_edital: "Chat com Edital",
+  disputa_ao_vivo: "Painel de Lances ao Vivo",
+  analytics_concorrencia: "Análise de Concorrência",
+  modulo_juridico: "Módulo Jurídico",
+};
+
+function supportWhatsAppUrl(prefilled: string): string {
+  const phone = process.env.NEXT_PUBLIC_SUPPORT_WHATSAPP_PHONE ?? "5582819990000";
+  return `https://api.whatsapp.com/send?phone=${phone}&text=${encodeURIComponent(prefilled)}`;
+}
+
+export function FeatureLockModal() {
+  const { modalData, closeModal } = useBilling();
+  const router = useRouter();
+
+  return (
+    <AnimatePresence>
+      {modalData && (
+        <motion.div
+          className="fixed inset-0 z-[200] flex items-center justify-center p-4"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            aria-label="Fechar"
+            onClick={closeModal}
+          />
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            className={cn(
+              "relative z-10 w-full max-w-md rounded-xl border bg-zinc-900 p-6 shadow-xl",
+              modalData.type === "FEATURE_LOCKED" && "border-zinc-800",
+              modalData.type === "USER_LIMIT_EXCEEDED" && "border-zinc-800",
+              modalData.type === "ACCOUNT_INACTIVE" && "border-zinc-800",
+            )}
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.96 }}
+            transition={{ duration: 0.2 }}
+          >
+            {modalData.type === "FEATURE_LOCKED" && (
+              <FeatureLockedBody
+                data={modalData}
+                onClose={closeModal}
+                onVerPlanos={() => {
+                  closeModal();
+                  router.push("/planos");
+                }}
+              />
+            )}
+            {modalData.type === "USER_LIMIT_EXCEEDED" && (
+              <UserLimitBody
+                data={modalData}
+                onClose={closeModal}
+                onVerPlanos={() => {
+                  closeModal();
+                  router.push("/planos");
+                }}
+              />
+            )}
+            {modalData.type === "ACCOUNT_INACTIVE" && (
+              <AccountInactiveBody data={modalData} onClose={closeModal} />
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function FeatureLockedBody({
+  data,
+  onClose,
+  onVerPlanos,
+}: {
+  data: { requiredPlan: string; feature: string };
+  onClose: () => void;
+  onVerPlanos: () => void;
+}) {
+  const planCommercial = PLAN_DISPLAY_NAMES[data.requiredPlan] ?? data.requiredPlan;
+  const featureLabel = FEATURE_DISPLAY_NAMES[data.feature] ?? data.feature;
+  const planRow = PLANS_DATA.find((p) => p.enum === data.requiredPlan);
+
+  return (
+    <>
+      <div className="flex justify-center mb-4">
+        <div className="rounded-full bg-[#0078D1]/15 p-3">
+          <Lock className="h-7 w-7 text-[#0078D1]" aria-hidden />
+        </div>
+      </div>
+      <h2 className="text-lg font-semibold text-center text-zinc-100">
+        Recurso exclusivo do plano {planCommercial}
+      </h2>
+      <p className="mt-2 text-sm text-center text-zinc-400">
+        Faça upgrade para desbloquear {featureLabel}.
+      </p>
+      {planRow && (
+        <ul className="mt-5 space-y-2 border-t border-zinc-800 pt-4">
+          {planRow.features.slice(0, 6).map((f) => (
+            <li key={f} className="flex gap-2 text-sm text-zinc-300">
+              <span className="shrink-0 text-[#0078D1]">✓</span>
+              {f}
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+        <Button
+          type="button"
+          variant="ghost"
+          className="text-zinc-400 hover:text-zinc-200"
+          onClick={onClose}
+        >
+          Fechar
+        </Button>
+        <Button
+          type="button"
+          className="bg-[#0078D1] hover:bg-[#0078D1]/90 text-white"
+          onClick={onVerPlanos}
+        >
+          Ver planos
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function UserLimitBody({
+  data,
+  onClose,
+  onVerPlanos,
+}: {
+  data: { maxAllowed: number; suggestedPlan: string };
+  onClose: () => void;
+  onVerPlanos: () => void;
+}) {
+  const suggestedName = PLAN_DISPLAY_NAMES[data.suggestedPlan] ?? data.suggestedPlan;
+
+  return (
+    <>
+      <div className="flex justify-center mb-4">
+        <div className="rounded-full bg-[#0078D1]/15 p-3">
+          <Users className="h-7 w-7 text-[#0078D1]" aria-hidden />
+        </div>
+      </div>
+      <h2 className="text-lg font-semibold text-center text-zinc-100">Limite de usuários atingido</h2>
+      <p className="mt-2 text-sm text-center text-zinc-400">
+        Seu plano permite até {data.maxAllowed} usuários. Faça upgrade para o plano {suggestedName}.
+      </p>
+      <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+        <Button
+          type="button"
+          variant="ghost"
+          className="text-zinc-400 hover:text-zinc-200"
+          onClick={onClose}
+        >
+          Fechar
+        </Button>
+        <Button
+          type="button"
+          className="bg-[#0078D1] hover:bg-[#0078D1]/90 text-white"
+          onClick={onVerPlanos}
+        >
+          Ver planos
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function AccountInactiveBody({
+  data,
+  onClose,
+}: {
+  data: { status: "SUSPENSO" | "CANCELADO" };
+  onClose: () => void;
+}) {
+  const titulo = data.status === "CANCELADO" ? "Conta cancelada" : "Conta suspensa";
+
+  return (
+    <>
+      <div className="flex justify-center mb-4">
+        <div className="rounded-full bg-amber-500/15 p-3">
+          <AlertTriangle className="h-7 w-7 text-amber-500" aria-hidden />
+        </div>
+      </div>
+      <h2 className="text-lg font-semibold text-center text-zinc-100">{titulo}</h2>
+      <p className="mt-2 text-sm text-center text-zinc-400">
+        Entre em contato com o suporte para reativar sua conta.
+      </p>
+      <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+        <Button
+          type="button"
+          variant="ghost"
+          className="text-zinc-400 hover:text-zinc-200"
+          onClick={onClose}
+        >
+          Fechar
+        </Button>
+        <Button
+          type="button"
+          className="bg-[#0078D1] hover:bg-[#0078D1]/90 text-white"
+          onClick={() => {
+            window.open(
+              supportWhatsAppUrl("Olá, preciso de ajuda com o status da minha conta no Limvex Licitação."),
+              "_blank",
+              "noopener,noreferrer",
+            );
+          }}
+        >
+          Falar com o suporte
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/juridico/JuridicoTab.tsx
+++ b/apps/web/src/components/juridico/JuridicoTab.tsx
@@ -14,6 +14,7 @@ import {
 import {
   atualizarStatusPeticao,
   gerarPeticaoDocx,
+  isBillingHandledError,
   listarPeticoesByBid,
   type Peticao,
   type TipoPeticao,
@@ -63,12 +64,16 @@ export function JuridicoTab({ bidId }: JuridicoTabProps) {
     try {
       const data = await listarPeticoesByBid(bidId);
       setPeticoes(data);
-    } catch (err: any) {
-      toast({
-        title: "Erro ao carregar histórico",
-        description: err?.message || "Não foi possível carregar as petições",
-        variant: "destructive",
-      });
+    } catch (err: unknown) {
+      if (!isBillingHandledError(err)) {
+        toast({
+          title: "Erro ao carregar histórico",
+          description: (err as Error)?.message || "Não foi possível carregar as petições",
+          variant: "destructive",
+        });
+      } else {
+        setPeticoes([]);
+      }
     } finally {
       setLoading(false);
     }
@@ -117,6 +122,14 @@ export function JuridicoTab({ bidId }: JuridicoTabProps) {
       });
       fecharModal();
       await carregarHistorico();
+    } catch (err: unknown) {
+      if (!isBillingHandledError(err)) {
+        toast({
+          title: "Erro ao gerar petição",
+          description: (err as Error)?.message || "Não foi possível gerar o documento.",
+          variant: "destructive",
+        });
+      }
     } finally {
       setGerando(false);
     }
@@ -137,12 +150,14 @@ export function JuridicoTab({ bidId }: JuridicoTabProps) {
         title: "Status atualizado",
         description: "Petição marcada como enviada.",
       });
-    } catch (err: any) {
-      toast({
-        title: "Erro ao atualizar status",
-        description: err?.message || "Não foi possível atualizar o status",
-        variant: "destructive",
-      });
+    } catch (err: unknown) {
+      if (!isBillingHandledError(err)) {
+        toast({
+          title: "Erro ao atualizar status",
+          description: (err as Error)?.message || "Não foi possível atualizar o status",
+          variant: "destructive",
+        });
+      }
     } finally {
       setAtualizandoId(null);
     }

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -9,6 +9,7 @@ import {
     BarChart2, Briefcase,
     TrendingUp, History, Tag as TagIcon,
     CalendarDays, Users, HelpCircle, Radio, UserSearch, PlayCircle, Puzzle,
+    CreditCard,
 } from "lucide-react";
 
 import { AlertsDropdown } from "@/components/AlertsDropdown";
@@ -29,9 +30,11 @@ import { cn } from "@/lib/utils";
 import { SupportDrawer } from "@/components/SupportDrawer";
 import { Logo } from "@/components/logo";
 import { OnboardingModal } from "@/components/onboarding/onboarding-modal";
+import { CanAccessFeature } from "@/components/billing/CanAccessFeature";
+import { FeatureLockModal } from "@/components/billing/FeatureLockModal";
 
 /* ─── Types ──────────────────────────────────────────────── */
-interface SubItem { label: string; href: string; icon?: any; }
+interface SubItem { label: string; href: string; icon?: any; feature?: string; }
 interface NavItem { label: string; icon: any; href: string; subItems?: SubItem[]; emDesenvolvimento?: boolean; }
 interface NavGroup { group: string; items: NavItem[]; }
 
@@ -60,7 +63,7 @@ const navGroups: NavGroup[] = [
                 subItems: [
                     { label: "Histórico de Compras", href: "/analise/historico-compras", icon: History },
                     { label: "Produtos", href: "/analise/produtos", icon: TagIcon },
-                    { label: "Concorrentes", href: "/analise/concorrentes", icon: UserSearch },
+                    { label: "Concorrentes", href: "/analise/concorrentes", icon: UserSearch, feature: "analytics_concorrencia" },
                 ]
             },
             {
@@ -69,7 +72,8 @@ const navGroups: NavGroup[] = [
                     { label: "Funil de licitações (Kanban)", href: "/negocios/funil", icon: TrendingUp },
                     { label: "Agenda", href: "/negocios/agenda", icon: CalendarDays },
                     { label: "Pregões (Central)", href: "/negocios/pregoes", icon: Gavel },
-                    { label: "Monitoramento", href: "/monitoramento", icon: Radio },
+                    { label: "Monitoramento", href: "/monitoramento", icon: Radio, feature: "monitoramento" },
+                    { label: "Disputa ao vivo", href: "/disputa", icon: PlayCircle, feature: "disputa_ao_vivo" },
                 ]
             },
             {
@@ -114,8 +118,8 @@ function NavDropdown({ item, pathname }: { item: NavItem; pathname: string }) {
                     {item.subItems.map((sub) => {
                         const subActive = pathname === sub.href;
                         const Icon = sub.icon;
-                        return (
-                            <Link key={sub.href} href={sub.href}
+                        const link = (
+                            <Link href={sub.href}
                                 className={cn(
                                     "flex items-center gap-2.5 mx-1 px-3 py-2 rounded-lg text-[13px] font-medium transition-colors",
                                     subActive
@@ -127,6 +131,13 @@ function NavDropdown({ item, pathname }: { item: NavItem; pathname: string }) {
                                 {Icon && <Icon className={cn("w-3.5 h-3.5 shrink-0", subActive ? "text-primary" : "text-gray-400 dark:text-gray-500")} />}
                                 {sub.label}
                             </Link>
+                        );
+                        return sub.feature ? (
+                            <CanAccessFeature key={sub.href} feature={sub.feature}>
+                                {link}
+                            </CanAccessFeature>
+                        ) : (
+                            <div key={sub.href}>{link}</div>
                         );
                     })}
                 </div>
@@ -244,16 +255,25 @@ function MobileSidebarContent({
                                     )}
                                     {hasSubItems && isSubmenuOpen && (
                                         <div className="ml-9 mt-0.5 space-y-0.5">
-                                            {(item.subItems ?? []).map(sub => (
-                                                <Link key={sub.href} href={sub.href}
-                                                    className={cn("block px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors",
-                                                        pathname === sub.href
-                                                            ? "text-primary dark:text-primary-300"
-                                                            : "text-gray-500 hover:text-gray-800 dark:text-gray-500 dark:hover:text-gray-200"
-                                                    )}>
-                                                    {sub.label}
-                                                </Link>
-                                            ))}
+                                            {(item.subItems ?? []).map(sub => {
+                                                const subLink = (
+                                                    <Link href={sub.href}
+                                                        className={cn("block px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors",
+                                                            pathname === sub.href
+                                                                ? "text-primary dark:text-primary-300"
+                                                                : "text-gray-500 hover:text-gray-800 dark:text-gray-500 dark:hover:text-gray-200"
+                                                        )}>
+                                                        {sub.label}
+                                                    </Link>
+                                                );
+                                                return sub.feature ? (
+                                                    <CanAccessFeature key={sub.href} feature={sub.feature}>
+                                                        {subLink}
+                                                    </CanAccessFeature>
+                                                ) : (
+                                                    <div key={sub.href}>{subLink}</div>
+                                                );
+                                            })}
                                         </div>
                                     )}
                                 </div>
@@ -391,6 +411,9 @@ export function Layout({ children, fullWidth = false }: {
                             <DropdownMenuItem asChild className="rounded-lg cursor-pointer">
                                 <Link href="/configuracoes"><Settings className="mr-2 h-4 w-4" /> Configurações</Link>
                             </DropdownMenuItem>
+                            <DropdownMenuItem asChild className="rounded-lg cursor-pointer">
+                                <Link href="/planos"><CreditCard className="mr-2 h-4 w-4" /> Planos</Link>
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                                 className="rounded-lg cursor-pointer"
                                 onSelect={() => setSupportOpen(true)}
@@ -457,6 +480,7 @@ export function Layout({ children, fullWidth = false }: {
             </main>
             <SupportDrawer open={supportOpen} onClose={() => setSupportOpen(false)} />
             <OnboardingModal forceOpen={tourOpen} onForceClose={() => setTourOpen(false)} />
+            <FeatureLockModal />
         </div>
     );
 }

--- a/apps/web/src/constants/plans.ts
+++ b/apps/web/src/constants/plans.ts
@@ -1,0 +1,98 @@
+// Mapeamento enum Prisma → nome comercial
+export const PLAN_DISPLAY_NAMES: Record<string, string> = {
+  STARTER: "Start",
+  PROFESSIONAL: "Growth",
+  ENTERPRISE: "Scale",
+};
+
+// Hierarquia de planos (index = nível)
+export const PLAN_HIERARCHY = ["STARTER", "PROFESSIONAL", "ENTERPRISE"] as const;
+export type PlanEnum = (typeof PLAN_HIERARCHY)[number];
+
+// Feature → plano mínimo requerido
+export const FEATURE_PLAN_MAP: Record<string, PlanEnum> = {
+  monitoramento: "PROFESSIONAL",
+  ia_analise_edital: "PROFESSIONAL",
+  ia_chat_edital: "PROFESSIONAL",
+  disputa_ao_vivo: "PROFESSIONAL",
+  analytics_concorrencia: "ENTERPRISE",
+  modulo_juridico: "ENTERPRISE",
+};
+
+// Checa se plano X tem acesso à feature
+export function hasFeatureAccess(userPlan: string, feature: string): boolean {
+  const required = FEATURE_PLAN_MAP[feature];
+  if (!required) return true;
+  const userIndex = PLAN_HIERARCHY.indexOf(userPlan as PlanEnum);
+  const requiredIndex = PLAN_HIERARCHY.indexOf(required);
+  if (userIndex < 0 || requiredIndex < 0) return false;
+  return userIndex >= requiredIndex;
+}
+
+export interface PlanCardData {
+  enum: PlanEnum;
+  name: string;
+  subtitle: string;
+  priceMonthly: number;
+  priceAnnual: number;
+  features: string[];
+  highlighted: boolean;
+  badge?: string;
+}
+
+// Dados dos planos para página /planos e modal
+export const PLANS_DATA: PlanCardData[] = [
+  {
+    enum: "STARTER",
+    name: "Start",
+    subtitle: "Performance",
+    priceMonthly: 499,
+    priceAnnual: 349,
+    features: [
+      "Até 2 usuários",
+      "Gestão de licitações",
+      "Controle de prazos",
+      "Checklist de documentos",
+      "Funil Kanban",
+      "Agenda integrada",
+    ],
+    highlighted: false,
+  },
+  {
+    enum: "PROFESSIONAL",
+    name: "Growth",
+    subtitle: "Performance",
+    priceMonthly: 799,
+    priceAnnual: 599,
+    features: [
+      "Tudo do Start +",
+      "Até 5 usuários",
+      "Monitoramento automático",
+      "Alertas de pregões",
+      "Integração com portais",
+      "Análise de edital com IA",
+      "Chat com edital",
+      "Painel de lances ao vivo",
+    ],
+    highlighted: true,
+    badge: "Popular",
+  },
+  {
+    enum: "ENTERPRISE",
+    name: "Scale",
+    subtitle: "Performance",
+    priceMonthly: 1299,
+    priceAnnual: 999,
+    features: [
+      "Tudo do Growth +",
+      "Usuários ilimitados",
+      "Operação multiempresa",
+      "Analytics completo",
+      "Análise de concorrência",
+      "Calculadora de lance",
+      "Geração automática de petições",
+      "Templates jurídicos completos",
+    ],
+    highlighted: false,
+  },
+];

--- a/apps/web/src/contexts/auth-context.tsx
+++ b/apps/web/src/contexts/auth-context.tsx
@@ -4,6 +4,8 @@ import React, { createContext, useContext, useState, useEffect } from "react";
 import type { User } from "@licitafacil/shared";
 import { useRouter, usePathname } from "next/navigation";
 import { getToken, getUser, setAuth, clearAuth } from "@/lib/auth";
+import { api } from "@/lib/api";
+import { PLAN_HIERARCHY, type PlanEnum } from "@/constants/plans";
 
 interface AuthContextType {
     user: User | null;
@@ -12,14 +14,25 @@ interface AuthContextType {
     logout: () => void;
     isLoading: boolean;
     markOnboardingComplete: () => void;
+    userPlan: PlanEnum;
+    planLoading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+function parsePlanEnum(value: string | undefined): PlanEnum {
+    if (value && (PLAN_HIERARCHY as readonly string[]).includes(value)) {
+        return value as PlanEnum;
+    }
+    return "STARTER";
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
     const [user, setUser] = useState<User | null>(null);
     const [token, setToken] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [userPlan, setUserPlan] = useState<PlanEnum>("STARTER");
+    const [planLoading, setPlanLoading] = useState(false);
     const router = useRouter();
     const pathname = usePathname();
 
@@ -36,6 +49,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setIsLoading(false);
     }, [pathname, router]);
 
+    useEffect(() => {
+        if (!user || !token) {
+            setUserPlan("STARTER");
+            setPlanLoading(false);
+            return;
+        }
+        let cancelled = false;
+        setPlanLoading(true);
+        api
+            .get<{ plano: string }>("/empresas/me/plano")
+            .then(({ data }) => {
+                if (!cancelled) setUserPlan(parsePlanEnum(data?.plano));
+            })
+            .catch(() => {
+                if (!cancelled) setUserPlan("STARTER");
+            })
+            .finally(() => {
+                if (!cancelled) setPlanLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [user, token]);
+
     const login = (newToken: string, newUser: User) => {
         setAuth(newToken, newUser);
         setToken(newToken);
@@ -46,6 +83,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         clearAuth();
         setToken(null);
         setUser(null);
+        setUserPlan("STARTER");
         router.push("/login");
     };
 
@@ -57,7 +95,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
 
     return (
-        <AuthContext.Provider value={{ user, token, login, logout, isLoading, markOnboardingComplete }}>
+        <AuthContext.Provider
+            value={{
+                user,
+                token,
+                login,
+                logout,
+                isLoading,
+                markOnboardingComplete,
+                userPlan,
+                planLoading,
+            }}
+        >
             {children}
         </AuthContext.Provider>
     );

--- a/apps/web/src/contexts/billing-context.tsx
+++ b/apps/web/src/contexts/billing-context.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from "react";
+import type { PlanEnum } from "@/constants/plans";
+import { registerBillingErrorHandler, unregisterBillingErrorHandler } from "@/lib/api";
+
+interface FeatureLockData {
+  type: "FEATURE_LOCKED";
+  currentPlan: PlanEnum;
+  requiredPlan: PlanEnum;
+  feature: string;
+}
+
+interface UserLimitData {
+  type: "USER_LIMIT_EXCEEDED";
+  currentCount: number;
+  maxAllowed: number;
+  suggestedPlan: PlanEnum;
+}
+
+interface AccountInactiveData {
+  type: "ACCOUNT_INACTIVE";
+  status: "SUSPENSO" | "CANCELADO";
+}
+
+type BillingModalData = FeatureLockData | UserLimitData | AccountInactiveData | null;
+
+interface BillingContextType {
+  modalData: BillingModalData;
+  showFeatureLock: (data: Omit<FeatureLockData, "type">) => void;
+  showUserLimit: (data: Omit<UserLimitData, "type">) => void;
+  showAccountInactive: (data: Omit<AccountInactiveData, "type">) => void;
+  closeModal: () => void;
+}
+
+const BillingContext = createContext<BillingContextType | null>(null);
+
+export function BillingProvider({ children }: { children: ReactNode }) {
+  const [modalData, setModalData] = useState<BillingModalData>(null);
+
+  const showFeatureLock = useCallback((data: Omit<FeatureLockData, "type">) => {
+    setModalData({ type: "FEATURE_LOCKED", ...data });
+  }, []);
+
+  const showUserLimit = useCallback((data: Omit<UserLimitData, "type">) => {
+    setModalData({ type: "USER_LIMIT_EXCEEDED", ...data });
+  }, []);
+
+  const showAccountInactive = useCallback((data: Omit<AccountInactiveData, "type">) => {
+    setModalData({ type: "ACCOUNT_INACTIVE", ...data });
+  }, []);
+
+  const closeModal = useCallback(() => setModalData(null), []);
+
+  useEffect(() => {
+    registerBillingErrorHandler((data) => {
+      if (data.code === "FEATURE_LOCKED") {
+        showFeatureLock({
+          currentPlan: data.currentPlan as PlanEnum,
+          requiredPlan: data.requiredPlan as PlanEnum,
+          feature: data.feature!,
+        });
+      } else if (data.code === "USER_LIMIT_EXCEEDED") {
+        showUserLimit({
+          currentCount: data.currentCount!,
+          maxAllowed: data.maxAllowed!,
+          suggestedPlan: data.suggestedPlan as PlanEnum,
+        });
+      } else if (data.code === "ACCOUNT_INACTIVE") {
+        showAccountInactive({ status: data.status as "SUSPENSO" | "CANCELADO" });
+      }
+    });
+    return () => unregisterBillingErrorHandler();
+  }, [showFeatureLock, showUserLimit, showAccountInactive]);
+
+  return (
+    <BillingContext.Provider
+      value={{ modalData, showFeatureLock, showUserLimit, showAccountInactive, closeModal }}
+    >
+      {children}
+    </BillingContext.Provider>
+  );
+}
+
+export function useBilling() {
+  const ctx = useContext(BillingContext);
+  if (!ctx) throw new Error("useBilling must be used within BillingProvider");
+  return ctx;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -8,6 +8,34 @@ export const api = axios.create({
   baseURL: API_URL,
 });
 
+/** Erro de 403 de billing já tratado pelo modal global (evita toast / tela de erro). */
+export function isBillingHandledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  return Boolean((error as { _billingHandled?: boolean })._billingHandled);
+}
+
+// Callback registrável para o BillingProvider reagir a 403 estruturados
+type BillingErrorHandler = (error: {
+  code: string;
+  currentPlan?: string;
+  requiredPlan?: string;
+  feature?: string;
+  currentCount?: number;
+  maxAllowed?: number;
+  suggestedPlan?: string;
+  status?: string;
+}) => void;
+
+let billingErrorHandler: BillingErrorHandler | null = null;
+
+export function registerBillingErrorHandler(handler: BillingErrorHandler) {
+  billingErrorHandler = handler;
+}
+
+export function unregisterBillingErrorHandler() {
+  billingErrorHandler = null;
+}
+
 // Interceptor to add token to requests (usa o mesmo token do auth)
 api.interceptors.request.use((config) => {
   if (typeof window !== "undefined") {
@@ -19,10 +47,25 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// Interceptor to handle unauthorized errors
+// Interceptor: 403 de billing (antes do 401) e não autorizado
 api.interceptors.response.use(
   (response) => response,
   (error) => {
+    if (error.response?.status === 403 && error.response?.data?.code) {
+      const data = error.response.data as { code?: string };
+      const code = data.code;
+      if (
+        billingErrorHandler &&
+        (code === "FEATURE_LOCKED" ||
+          code === "USER_LIMIT_EXCEEDED" ||
+          code === "ACCOUNT_INACTIVE")
+      ) {
+        billingErrorHandler(data as Parameters<BillingErrorHandler>[0]);
+        (error as { _billingHandled?: boolean })._billingHandled = true;
+        return Promise.reject(error);
+      }
+    }
+
     if (error.response?.status === 401) {
       if (typeof window !== "undefined") {
         clearAuth();
@@ -32,7 +75,7 @@ api.interceptors.response.use(
       }
     }
     return Promise.reject(error);
-  }
+  },
 );
 
 // --- Checklist (itens de checklist da licitação) ---


### PR DESCRIPTION
## PL-02 — UX de Bloqueio e Upsell

### O que foi feito
- **FeatureLockModal** — modal global que intercepta 403 do backend (FEATURE_LOCKED, USER_LIMIT_EXCEEDED, ACCOUNT_INACTIVE)
- **BillingContext** — contexto React que gerencia estado dos modais + bridge com interceptor axios
- **Interceptor axios** — detecta 403 com code estruturado e dispara modal automaticamente
- **CanAccessFeature** — wrapper que desabilita itens do menu com tooltip indicando plano necessário
- **Página /planos** — comparativo dos 3 planos (Start R$349 / Growth R$599 / Scale R$999), highlight do plano atual, botão de contato para upgrade
- **constants/plans.ts** — fonte única de verdade para nomes, preços e features dos planos
- **GET /empresas/me/plano** — expõe o plano da empresa para COLABORADOR e ADMIN (antes só existia limite em /users/limite para ADMIN)

### Screenshots
(adicionar screenshots do modal e da página de planos após implementação)

### Validações
- Usuário STARTER acessando /monitoramento → modal de upsell (não tela branca)
- Itens bloqueados no menu → opacity 50% + tooltip
- Página /planos renderiza em mobile e desktop
- `pnpm --filter @licitafacil/web typecheck` ✅
- `pnpm --filter @licitafacil/web build` ✅

### Depende de
- PL-01 (#182) — ✅ Mergeado

Closes #183

Made with [Cursor](https://cursor.com)