### PR TITLE
feat(disputa): L04 — Integração monitoramento → disputa

### DIFF
--- a/apps/api/prisma/migrations/20260413190500_add_numero_pregao_disputa_if_missing/migration.sql
+++ b/apps/api/prisma/migrations/20260413190500_add_numero_pregao_disputa_if_missing/migration.sql
@@ -1,0 +1,5 @@
+-- Garante colunas usadas pelo DisputaService em bancos que não aplicaram a migration L02 completa.
+-- IF NOT EXISTS evita falha em ambientes que já possuem as colunas.
+
+ALTER TABLE "Disputa" ADD COLUMN IF NOT EXISTS "numeroPregao" TEXT NOT NULL DEFAULT 'NI';
+ALTER TABLE "Disputa" ADD COLUMN IF NOT EXISTS "uasg" TEXT NOT NULL DEFAULT 'NI';

--- a/apps/api/src/disputa/disputa.controller.ts
+++ b/apps/api/src/disputa/disputa.controller.ts
@@ -44,7 +44,7 @@ export class DisputaController {
     if (paginar) {
       return this.disputaService.listarDisputasPaginado(empresaId, query);
     }
-    return this.disputaService.listarDisputas(empresaId);
+    return this.disputaService.listarDisputas(empresaId, query);
   }
 
   /**

--- a/apps/api/src/disputa/disputa.service.ts
+++ b/apps/api/src/disputa/disputa.service.ts
@@ -138,13 +138,24 @@ export class DisputaService {
     return this.sanitizarDisputa(disputa);
   }
 
+  private buildDisputaListWhere(
+    empresaId: string,
+    query?: Pick<ListarDisputasQueryDto, "status" | "bidId" | "numeroPregao">,
+  ): Prisma.DisputaWhereInput {
+    const where: Prisma.DisputaWhereInput = { empresaId };
+    if (query?.status) where.status = query.status;
+    if (query?.bidId) where.bidId = query.bidId;
+    const np = query?.numeroPregao?.trim();
+    if (np) where.numeroPregao = np;
+    return where;
+  }
+
   async listarDisputasPaginado(empresaId: string, query: ListarDisputasQueryDto) {
     const page = query.page && query.page > 0 ? query.page : 1;
     const limit = query.limit && query.limit > 0 && query.limit <= 100 ? query.limit : 10;
     const skip = (page - 1) * limit;
 
-    const where: Prisma.DisputaWhereInput = { empresaId };
-    if (query.status) where.status = query.status;
+    const where = this.buildDisputaListWhere(empresaId, query);
 
     const [total, disputas] = await Promise.all([
       this.prisma.disputa.count({ where }),
@@ -385,9 +396,11 @@ export class DisputaService {
     return { ok: true };
   }
 
-  async listarDisputas(empresaId: string) {
+  async listarDisputas(empresaId: string, query?: ListarDisputasQueryDto) {
+    const where = this.buildDisputaListWhere(empresaId, query);
+
     const disputas = await this.prisma.disputa.findMany({
-      where: { empresaId },
+      where,
       include: {
         bid: true,
         credencial: true,

--- a/apps/api/src/disputa/dto/listar-disputas.dto.ts
+++ b/apps/api/src/disputa/dto/listar-disputas.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from "class-transformer";
-import { IsEnum, IsInt, IsOptional, Max, Min } from "class-validator";
+import { IsEnum, IsInt, IsOptional, IsString, IsUUID, Max, Min } from "class-validator";
 import { DisputaStatus } from "@prisma/client";
 
 export class ListarDisputasQueryDto {
@@ -19,4 +19,13 @@ export class ListarDisputasQueryDto {
   @IsOptional()
   @IsEnum(DisputaStatus)
   status?: DisputaStatus;
+
+  @IsOptional()
+  @IsUUID()
+  bidId?: string;
+
+  /** Filtro exato pelo número do pregão gravado na disputa */
+  @IsOptional()
+  @IsString()
+  numeroPregao?: string;
 }

--- a/apps/web/src/app/configuracoes/page.tsx
+++ b/apps/web/src/app/configuracoes/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Layout } from "@/components/layout";
 import {
     Settings, User, Bell, ShieldCheck, ChevronRight,
-    Moon, Sun, Monitor, CheckCircle2, Lock,
+    Moon, Sun, Monitor, CheckCircle2, Lock, Puzzle,
 } from "lucide-react";
 import { useAuth } from "@/contexts/auth-context";
 import { cn } from "@/lib/utils";
@@ -170,6 +170,14 @@ export default function ConfiguracoesPage() {
                         iconBg="bg-amber-50 dark:bg-amber-950/50"
                         title="Notificações por Email"
                         description="Controle quais alertas você recebe e com qual frequência"
+                    />
+                    <SectionCard
+                        href="/extensao"
+                        icon={Puzzle}
+                        iconColor="text-violet-600 dark:text-violet-400"
+                        iconBg="bg-violet-50 dark:bg-violet-950/50"
+                        title="Extensão Chrome"
+                        description="Instale e use a extensão para integrar com portais de licitação"
                     />
                     <SectionCard
                         href="/redefinir-senha"

--- a/apps/web/src/app/disputa/page.tsx
+++ b/apps/web/src/app/disputa/page.tsx
@@ -45,7 +45,7 @@ export default function DisputaPage() {
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["disputas"],
-    queryFn: listarDisputas,
+    queryFn: () => listarDisputas(),
     staleTime: 8000,
     refetchInterval: 10000,
     retry: 1,

--- a/apps/web/src/app/licitacoes/[id]/page.tsx
+++ b/apps/web/src/app/licitacoes/[id]/page.tsx
@@ -35,9 +35,11 @@ import { PredictionModal } from "@/components/licitacoes/prediction-modal";
 import { PredictiveAnalysis } from "@/components/licitacoes/PredictiveAnalysis";
 import { EditarLicitacaoModal } from "@/components/licitacoes/EditarLicitacaoModal";
 import { CalculadoraLance } from "@/components/licitacoes/calculadora-lance";
+import { LicitacaoDisputasSection } from "@/components/licitacoes/LicitacaoDisputasSection";
 import type { Bid } from "@licitafacil/shared";
 import { useQuery } from "@tanstack/react-query";
 import { listarPregoesMonitorados } from "@/lib/api";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 type PregaoVinculado = {
   id: string;
@@ -458,6 +460,12 @@ export default function LicitacaoDetailPage() {
             </div>
           )}
 
+        <Tabs defaultValue="visao" className="w-full">
+          <TabsList className="mb-4">
+            <TabsTrigger value="visao">Visão geral</TabsTrigger>
+            <TabsTrigger value="disputa">Disputa</TabsTrigger>
+          </TabsList>
+          <TabsContent value="visao" className="mt-0 space-y-8">
         {/* Info Grid */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
           <Card className="lg:col-span-2 shadow-sm border-gray-200 dark:border-gray-700">
@@ -632,6 +640,16 @@ export default function LicitacaoDetailPage() {
             </CardContent>
           </Card>
         )}
+          </TabsContent>
+
+          <TabsContent value="disputa" className="mt-0">
+            <LicitacaoDisputasSection
+              bidId={id}
+              licitacaoTitle={licitacao.title}
+              licitacaoAgency={licitacao.agency}
+            />
+          </TabsContent>
+        </Tabs>
       </div>
 
       {/* Modal de Análise Preditiva */}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
   BarChart2, ArrowRight, FileText, Calendar,
   Plus, ChevronRight, Zap,
 } from "lucide-react";
+import { listarDisputas, type Disputa } from "@/lib/api";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { Layout } from "@/components/layout";
@@ -77,6 +78,19 @@ export default function DashboardPage() {
   const totalPregoesHoje = (pregoesHoje ?? []).filter((p: any) =>
     ["AGUARDANDO", "EM_DISPUTA"].includes(p?.status)
   ).length;
+
+  const { data: disputasAtivas = [] } = useQuery({
+    queryKey: ["disputas-ativas-dashboard"],
+    queryFn: async () => {
+      const list = await listarDisputas({ status: "AO_VIVO" });
+      return Array.isArray(list) ? list : [];
+    },
+    staleTime: 30_000,
+  });
+
+  const disputasAoVivo = (disputasAtivas as Disputa[]).filter((d) =>
+    ["AO_VIVO", "INICIANDO", "PAUSADA"].includes(d.status)
+  );
 
   const totalOpen = overviewStats?.emAndamento ?? 0;
   const totalAtRisk = overviewStats?.emRisco ?? 0;
@@ -216,6 +230,44 @@ export default function DashboardPage() {
                   </button>
                 </Link>
               </div>
+            </div>
+
+            {/* Disputas ao vivo */}
+            <div
+              className="lg:col-span-5 rounded-xl border border-gray-100 bg-white p-5 dark:border-gray-800 dark:bg-gray-900 animate-fade-up"
+              style={{ animationDelay: "90ms" }}
+            >
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
+                  Disputas ativas
+                </h2>
+                {disputasAoVivo.length > 0 && (
+                  <span className="relative flex h-2 w-2">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75" />
+                    <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
+                  </span>
+                )}
+              </div>
+              {disputasAoVivo.length === 0 ? (
+                <p className="text-xs text-muted-foreground">Nenhuma disputa em andamento</p>
+              ) : (
+                <div className="space-y-2">
+                  {disputasAoVivo.map((d) => (
+                    <Link
+                      key={d.id}
+                      href={`/disputa/${d.id}/ao-vivo`}
+                      className="flex items-center justify-between rounded-lg p-2 transition-colors hover:bg-gray-50 dark:hover:bg-zinc-800/50"
+                    >
+                      <span className="max-w-[220px] truncate text-sm text-gray-800 dark:text-gray-200">
+                        {d.numeroPregao || "Disputa"}
+                      </span>
+                      <span className="animate-pulse rounded px-2 py-0.5 text-xs font-medium bg-red-500/20 text-red-400">
+                        AO VIVO
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* Prazos */}

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import {
     LayoutDashboard, Gavel, Settings,
     User, LogOut, Menu, FileText, BarChart3,
-    Globe, ShieldCheck, ChevronDown, ClipboardList,
+    ShieldCheck, ChevronDown, ClipboardList,
     BarChart2, Briefcase,
     TrendingUp, History, Tag as TagIcon,
     CalendarDays, Users, HelpCircle, Radio, UserSearch, PlayCircle, Puzzle,
@@ -75,12 +75,6 @@ const navGroups: NavGroup[] = [
                     { label: "Monitoramento", href: "/monitoramento", icon: Radio, feature: "monitoramento" },
                     { label: "Disputa ao vivo", href: "/disputa", icon: PlayCircle, feature: "disputa_ao_vivo" },
                 ]
-            },
-            {
-                label: "Buscar", icon: Globe, href: "/integracoes/comprasnet",
-            },
-            {
-                label: "Extensão Chrome", icon: Puzzle, href: "/extensao",
             },
         ]
     },
@@ -410,6 +404,9 @@ export function Layout({ children, fullWidth = false }: {
                             </DropdownMenuItem>
                             <DropdownMenuItem asChild className="rounded-lg cursor-pointer">
                                 <Link href="/configuracoes"><Settings className="mr-2 h-4 w-4" /> Configurações</Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild className="rounded-lg cursor-pointer">
+                                <Link href="/extensao"><Puzzle className="mr-2 h-4 w-4" /> Extensão Chrome</Link>
                             </DropdownMenuItem>
                             <DropdownMenuItem asChild className="rounded-lg cursor-pointer">
                                 <Link href="/planos"><CreditCard className="mr-2 h-4 w-4" /> Planos</Link>

--- a/apps/web/src/components/licitacoes/LicitacaoDisputasSection.tsx
+++ b/apps/web/src/components/licitacoes/LicitacaoDisputasSection.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import { Swords } from 'lucide-react'
+import { listarDisputas, type Disputa } from '@/lib/api'
+import { IniciarDisputaModal } from '@/components/monitoramento/IniciarDisputaModal'
+import type { PregaoMonitorado } from '@/components/monitoramento/CardPregao'
+
+function badgeAoVivo(d: Disputa) {
+  return d.status === 'AO_VIVO' || d.status === 'INICIANDO' || d.status === 'PAUSADA'
+}
+
+function labelResultado(d: Disputa) {
+  if (d.resultado && d.resultado !== 'EM_ANDAMENTO') {
+    const map: Record<string, string> = {
+      GANHOU: 'Ganhou',
+      PERDEU: 'Perdeu',
+      DESISTIU: 'Desistiu',
+      CANCELADO: 'Cancelado',
+    }
+    return map[d.resultado] ?? d.resultado
+  }
+  if (d.status === 'ENCERRADA') return 'Encerrada'
+  return null
+}
+
+export function LicitacaoDisputasSection({
+  bidId,
+  licitacaoTitle,
+  licitacaoAgency,
+}: {
+  bidId: string
+  licitacaoTitle: string
+  licitacaoAgency: string
+}) {
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const { data: disputas = [], isLoading } = useQuery({
+    queryKey: ['disputas', 'bid', bidId],
+    queryFn: () => listarDisputas({ bidId }),
+    enabled: Boolean(bidId),
+  })
+
+  const pregaoSintetico: PregaoMonitorado = {
+    numeroPregao: licitacaoTitle.slice(0, 120),
+    objeto: licitacaoTitle,
+    orgao: licitacaoAgency,
+    portal: 'COMPRASNET',
+    status: 'AGUARDANDO',
+    horarioInicio: new Date().toISOString(),
+    urlSalaDisputa: '#',
+  }
+
+  return (
+    <div className="space-y-4">
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Carregando disputas...</p>
+      ) : disputas.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200 py-12 text-center dark:border-gray-700">
+          <Swords className="mb-4 h-12 w-12 text-muted-foreground/30" />
+          <p className="mb-4 text-sm text-muted-foreground">
+            Nenhuma disputa vinculada a esta licitação
+          </p>
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            className="rounded-lg bg-[#0078D1] px-4 py-2 text-sm font-medium text-white hover:bg-[#0078D1]/90"
+          >
+            Iniciar disputa para esta licitação
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {disputas.map((disputa) => (
+            <div
+              key={disputa.id}
+              className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50/50 p-4 dark:border-gray-800 dark:bg-zinc-900/50 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {disputa.numeroPregao || 'Disputa'}
+                </span>
+                <span className="ml-2 text-xs text-muted-foreground">
+                  {new Date(disputa.createdAt).toLocaleDateString('pt-BR')}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                {badgeAoVivo(disputa) && (
+                  <span className="animate-pulse rounded px-2 py-0.5 text-xs font-medium bg-red-500/20 text-red-400">
+                    AO VIVO
+                  </span>
+                )}
+                {!badgeAoVivo(disputa) && labelResultado(disputa) && (
+                  <span className="rounded bg-zinc-200 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-700 dark:text-zinc-400">
+                    {labelResultado(disputa)}
+                  </span>
+                )}
+                <Link href={`/disputa/${disputa.id}/ao-vivo`}>
+                  <button
+                    type="button"
+                    className="text-sm font-medium text-[#0078D1] hover:underline"
+                  >
+                    {badgeAoVivo(disputa) ? 'Ver ao vivo' : 'Ver detalhes'}
+                  </button>
+                </Link>
+              </div>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            className="w-full rounded-lg border border-dashed border-gray-300 py-2 text-sm text-muted-foreground hover:border-[#0078D1]/50 hover:text-[#0078D1] dark:border-gray-700"
+          >
+            Iniciar outra disputa
+          </button>
+        </div>
+      )}
+
+      <IniciarDisputaModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        pregao={pregaoSintetico}
+        bidIdInicial={bidId}
+        ocultarSelectLicitacao
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/monitoramento/CardPregao.tsx
+++ b/apps/web/src/components/monitoramento/CardPregao.tsx
@@ -1,6 +1,9 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
-import { ExternalLink, Clock, TrendingDown, Plus, ClipboardEdit } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { ExternalLink, Clock, TrendingDown, Plus, ClipboardEdit, Swords } from 'lucide-react'
+import { listarDisputas } from '@/lib/api'
+import { IniciarDisputaModal } from '@/components/monitoramento/IniciarDisputaModal'
 
 export interface PregaoMonitorado {
   id?: string
@@ -69,7 +72,10 @@ function useCountdown(horario: string) {
 }
 
 export function CardPregao({ pregao, onCriarLicitacao, criandoLicitacao, onRegistrarResultado }: CardPregaoProps) {
+  const router = useRouter()
   const { texto: countdown, ref: cardRef } = useCountdown(pregao.horarioInicio)
+  const [showDisputaModal, setShowDisputaModal] = useState(false)
+  const [acompanharLoading, setAcompanharLoading] = useState(false)
 
   const temUrlPortal = pregao.urlSalaDisputa &&
     !pregao.urlSalaDisputa.includes('pncp.gov.br') &&
@@ -80,6 +86,30 @@ export function CardPregao({ pregao, onCriarLicitacao, criandoLicitacao, onRegis
     : <span className="text-xs text-yellow-500 flex items-center gap-1">🟡 Abre no PNCP</span>
 
   const urlAbrir = pregao.urlSalaDisputa || pregao.urlFallbackPncp || '#'
+
+  const handleDisputaClick = async () => {
+    const np = pregao.numeroPregao?.trim()
+    if (pregao.status === 'EM_DISPUTA' && np) {
+      setAcompanharLoading(true)
+      try {
+        const lista = await listarDisputas({ numeroPregao: np })
+        const match = lista.find(
+          (d) =>
+            d.numeroPregao === np &&
+            ['INICIANDO', 'AO_VIVO', 'PAUSADA'].includes(d.status),
+        )
+        if (match) {
+          router.push(`/disputa/${match.id}/ao-vivo`)
+          return
+        }
+      } catch {
+        // abre modal
+      } finally {
+        setAcompanharLoading(false)
+      }
+    }
+    setShowDisputaModal(true)
+  }
 
   return (
     <div ref={cardRef} className={`bg-card border rounded-lg p-4 flex flex-col gap-3 transition-all
@@ -115,17 +145,40 @@ export function CardPregao({ pregao, onCriarLicitacao, criandoLicitacao, onRegis
         </div>
       )}
 
-      <div className="flex items-center justify-between pt-1 border-t border-border">
+      <div className="flex flex-wrap items-center justify-between gap-2 pt-1 border-t border-border">
         {urlBadge}
-        <a
-          href={urlAbrir}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-        >
-          Abrir <ExternalLink className="h-3 w-3" />
-        </a>
+        <div className="flex flex-wrap items-center gap-2">
+          {(pregao.status === 'AGUARDANDO' || pregao.status === 'EM_DISPUTA') && (
+            <button
+              type="button"
+              onClick={() => void handleDisputaClick()}
+              disabled={acompanharLoading}
+              className="flex items-center gap-2 rounded-lg bg-[#0078D1]/10 px-3 py-1.5 text-sm font-medium text-[#0078D1] transition-colors hover:bg-[#0078D1]/20 disabled:opacity-60"
+            >
+              <Swords className="h-4 w-4" />
+              {acompanharLoading
+                ? 'Abrindo...'
+                : pregao.status === 'EM_DISPUTA'
+                  ? 'Acompanhar disputa'
+                  : 'Iniciar disputa'}
+            </button>
+          )}
+          <a
+            href={urlAbrir}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Abrir <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
       </div>
+
+      <IniciarDisputaModal
+        open={showDisputaModal}
+        onClose={() => setShowDisputaModal(false)}
+        pregao={pregao}
+      />
 
       {onCriarLicitacao && (
         <div className="flex items-center justify-between pt-1 border-t border-border">

--- a/apps/web/src/components/monitoramento/IniciarDisputaModal.tsx
+++ b/apps/web/src/components/monitoramento/IniciarDisputaModal.tsx
@@ -1,0 +1,233 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  buscarLicitacoes,
+  criarDisputa,
+  type LicitacaoResumo,
+  type PortalDisputa,
+} from '@/lib/api'
+
+function isBillingHandledError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  return Boolean((error as { _billingHandled?: boolean })._billingHandled)
+}
+import { useToast } from '@/hooks/use-toast'
+import type { PregaoMonitorado } from '@/components/monitoramento/CardPregao'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+
+const LABEL_PORTAL: Record<string, string> = {
+  COMPRASNET: 'ComprasNet',
+  BNC: 'BNC',
+  PNCP: 'PNCP',
+}
+
+/** Converte portal do monitoramento (PNCP/BNC/COMPRASNET) para o enum da disputa (apenas COMPRASNET | BNC). */
+export function portalMonitoramentoParaDisputa(portal: string): PortalDisputa {
+  const p = portal.trim().toUpperCase()
+  if (p === 'BNC') return 'BNC'
+  return 'COMPRASNET'
+}
+
+export interface IniciarDisputaModalProps {
+  open: boolean
+  onClose: () => void
+  pregao: PregaoMonitorado
+  /** Pré-seleciona vínculo (ex.: tab da licitação) */
+  bidIdInicial?: string
+  /** Oculta o select e fixa bidIdInicial */
+  ocultarSelectLicitacao?: boolean
+}
+
+export function IniciarDisputaModal({
+  open,
+  onClose,
+  pregao,
+  bidIdInicial,
+  ocultarSelectLicitacao,
+}: IniciarDisputaModalProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [loading, setLoading] = useState(false)
+  const [licitacoes, setLicitacoes] = useState<LicitacaoResumo[]>([])
+  const [loadingBids, setLoadingBids] = useState(false)
+  const [bidId, setBidId] = useState<string>('')
+
+  const portalDisputa = useMemo(() => portalMonitoramentoParaDisputa(pregao.portal), [pregao.portal])
+
+  useEffect(() => {
+    if (!open) return
+    setBidId(bidIdInicial && ocultarSelectLicitacao ? bidIdInicial : '')
+    if (ocultarSelectLicitacao && bidIdInicial) {
+      setBidId(bidIdInicial)
+      return
+    }
+    let cancelled = false
+    setLoadingBids(true)
+    buscarLicitacoes()
+      .then((data) => {
+        if (!cancelled) setLicitacoes(data)
+      })
+      .catch(() => {
+        if (!cancelled) setLicitacoes([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingBids(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, bidIdInicial, ocultarSelectLicitacao])
+
+  useEffect(() => {
+    if (open && bidIdInicial && !ocultarSelectLicitacao) {
+      setBidId(bidIdInicial)
+    }
+  }, [open, bidIdInicial, ocultarSelectLicitacao])
+
+  if (!open) return null
+
+  const horarioFmt = (() => {
+    try {
+      return new Date(pregao.horarioInicio).toLocaleString('pt-BR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    } catch {
+      return pregao.horarioInicio
+    }
+  })()
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    try {
+      const vinculo = ocultarSelectLicitacao ? bidIdInicial : bidId
+      const created = await criarDisputa({
+        portal: portalDisputa,
+        numeroPregao: pregao.numeroPregao?.trim() || undefined,
+        bidId: vinculo || undefined,
+      })
+      toast({ title: 'Disputa iniciada', description: 'Redirecionando para a sala ao vivo.' })
+      router.push(`/disputa/${created.id}/ao-vivo`)
+      onClose()
+    } catch (error: unknown) {
+      if (isBillingHandledError(error)) return
+      const msg =
+        error &&
+        typeof error === 'object' &&
+        'response' in error &&
+        error.response &&
+        typeof error.response === 'object' &&
+        'data' in error.response &&
+        error.response.data &&
+        typeof error.response.data === 'object' &&
+        'message' in error.response.data
+          ? String((error.response.data as { message?: unknown }).message)
+          : 'Erro ao iniciar disputa'
+      toast({ title: 'Não foi possível iniciar', description: msg, variant: 'destructive' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={() => !loading && onClose()}
+        aria-label="Fechar"
+      />
+      <div
+        className="relative z-10 w-full max-w-lg rounded-xl border border-zinc-800 bg-zinc-900 p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-2">
+          <h2 className="text-lg font-semibold text-zinc-100">Iniciar Disputa</h2>
+          <span className="rounded-full border border-zinc-700 bg-zinc-800 px-2.5 py-0.5 text-xs font-medium text-zinc-300">
+            {LABEL_PORTAL[pregao.portal] ?? pregao.portal}
+          </span>
+        </div>
+
+        <div className="mb-4 space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/50 p-3 text-sm text-zinc-300">
+          <p>
+            <span className="text-zinc-500">Número:</span> {pregao.numeroPregao}
+          </p>
+          <p className="line-clamp-3">
+            <span className="text-zinc-500">Objeto:</span> {pregao.objeto || '—'}
+          </p>
+          <p>
+            <span className="text-zinc-500">Órgão:</span> {pregao.orgao || '—'}
+          </p>
+          <p>
+            <span className="text-zinc-500">Horário da sessão:</span> {horarioFmt}
+          </p>
+        </div>
+
+        {!ocultarSelectLicitacao && (
+          <div className="mb-6 space-y-2">
+            <p className="text-xs font-medium text-zinc-400">Vincular à licitação (opcional)</p>
+            <Select
+              value={bidId || '__none__'}
+              onValueChange={(v) => setBidId(v === '__none__' ? '' : v)}
+              disabled={loadingBids}
+            >
+              <SelectTrigger className="border-zinc-700 bg-zinc-950 text-zinc-100">
+                <SelectValue
+                  placeholder={loadingBids ? 'Carregando...' : 'Nenhuma — criar disputa avulsa'}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">Nenhuma — criar disputa avulsa</SelectItem>
+                {licitacoes.map((b) => (
+                  <SelectItem key={b.id} value={b.id}>
+                    <span className="line-clamp-1">
+                      {b.title} · {b.agency}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {ocultarSelectLicitacao && bidIdInicial && (
+          <p className="mb-6 text-xs text-zinc-500">
+            Esta disputa será vinculada à licitação atual.
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="border-zinc-700 bg-transparent text-zinc-200 hover:bg-zinc-800"
+            onClick={() => onClose()}
+            disabled={loading}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            className="bg-[#0078D1] text-white hover:bg-[#0066b3]"
+            disabled={loading}
+            onClick={() => void handleConfirm()}
+          >
+            {loading ? 'Iniciando...' : 'Iniciar disputa'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -165,6 +165,7 @@ export interface Disputa {
   encerradoEm?: string | null;
   numeroPregao?: string;
   uasg?: string;
+  resultado?: "EM_ANDAMENTO" | "GANHOU" | "PERDEU" | "CANCELADO" | "DESISTIU";
   credencial: DisputaCredencialPublica | null;
   configuracoes: DisputaConfiguracao[];
   historico?: Array<{
@@ -214,8 +215,12 @@ export async function buscarLicitacoes(): Promise<LicitacaoResumo[]> {
   return data?.data ?? [];
 }
 
-export async function listarDisputas(): Promise<Disputa[]> {
-  const { data } = await api.get("/disputa");
+export async function listarDisputas(params?: {
+  status?: DisputaStatus;
+  bidId?: string;
+  numeroPregao?: string;
+}): Promise<Disputa[]> {
+  const { data } = await api.get("/disputa", { params });
   return data;
 }
 


### PR DESCRIPTION
## L04 — Integração monitoramento → disputa

### O que foi feito

**Backend:**
- Filtros `bidId` e `numeroPregao` no `GET /disputa`
- `buildDisputaListWhere` centraliza lógica de filtros

**Monitoramento:**
- Botão 'Iniciar disputa' (AGUARDANDO) / 'Acompanhar disputa' (EM_DISPUTA) nos cards de pregão
- `IniciarDisputaModal` com dados read-only do pregão + select opcional de licitação
- Mapeamento de portal (PNCP → COMPRASNET, BNC → BNC)

**Licitação:**
- Tab 'Disputa' na página de detalhe com lista de disputas vinculadas
- Estado vazio com botão para iniciar disputa pré-vinculada
- Badge AO VIVO com link direto

**Dashboard:**
- Widget 'Disputas ativas' com badge AO VIVO e link direto

### Fluxo
1. Monitoramento → 'Iniciar disputa' → modal com dados do pregão
2. Confirma → POST /disputa → redireciona para /disputa/[id]/ao-vivo
3. Disputa aparece na tab da licitação e no widget do dashboard

### Validações
- Fluxo monitoramento → disputa → ao vivo funciona
- Filtro bidId retorna disputas corretas
- Tab Disputa exibe histórico
- `typecheck` web + api ✅
- `build` web + api ✅

Closes #178