### PR TITLE
feat(admin): PL-03 painel de billing manual

### DIFF
--- a/apps/api/prisma/seed-clientes-pl03.ts
+++ b/apps/api/prisma/seed-clientes-pl03.ts
@@ -1,0 +1,155 @@
+import { PrismaClient, PlanoTipo, ClienteStatus, UserRole } from "@prisma/client";
+import * as bcrypt from "bcrypt";
+
+const prisma = new PrismaClient();
+
+function addDays(base: Date, days: number) {
+  const d = new Date(base);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+async function upsertCliente(options: {
+  empresaId: string;
+  empresaNome: string;
+  cnpj: string;
+  emailComercial: string;
+  plano: PlanoTipo;
+  status: ClienteStatus;
+  maxUsuarios: number;
+  dataProximaCobranca: Date;
+  criarUsuarios: number;
+}) {
+  const senhaHash = await bcrypt.hash("Admin@123", 10);
+
+  const empresa = await prisma.empresa.upsert({
+    where: { id: options.empresaId },
+    update: { name: options.empresaNome },
+    create: { id: options.empresaId, name: options.empresaNome },
+  });
+
+  await prisma.clienteConfig.upsert({
+    where: { empresaId: empresa.id },
+    update: {
+      cnpj: options.cnpj,
+      email: options.emailComercial,
+      plano: options.plano,
+      status: options.status,
+      maxUsuarios: options.maxUsuarios,
+      dataProximaCobranca: options.dataProximaCobranca,
+      deletedAt: null,
+    },
+    create: {
+      empresaId: empresa.id,
+      cnpj: options.cnpj,
+      email: options.emailComercial,
+      plano: options.plano,
+      status: options.status,
+      valorSetup: 0,
+      mensalidade: 0,
+      dataInicio: new Date(),
+      dataProximaCobranca: options.dataProximaCobranca,
+      maxUsuarios: options.maxUsuarios,
+    },
+  });
+
+  // garante um admin do tenant para login/teste
+  await prisma.user.upsert({
+    where: { email: `admin+${options.empresaId}@limvex.com.br` },
+    update: { empresaId: empresa.id, deletedAt: null },
+    create: {
+      name: `Admin ${options.empresaNome}`,
+      email: `admin+${options.empresaId}@limvex.com.br`,
+      password: senhaHash,
+      role: UserRole.ADMIN,
+      empresaId: empresa.id,
+    },
+  });
+
+  // cria usuários adicionais para simular downgrade inválido/limites
+  for (let i = 1; i <= options.criarUsuarios; i++) {
+    const email = `user${i}+${options.empresaId}@limvex.com.br`;
+    await prisma.user.upsert({
+      where: { email },
+      update: { empresaId: empresa.id, deletedAt: null },
+      create: {
+        name: `User ${i} ${options.empresaNome}`,
+        email,
+        password: senhaHash,
+        role: UserRole.COLABORADOR,
+        empresaId: empresa.id,
+      },
+    });
+  }
+
+  return empresa;
+}
+
+export async function seedClientesPL03() {
+  const now = new Date();
+
+  const clientes = [
+    {
+      empresaId: "11111111-1111-1111-1111-111111111111",
+      empresaNome: "Cliente Seed Starter (2 users)",
+      cnpj: "11.111.111/0001-11",
+      emailComercial: "financeiro+starter@limvex.com.br",
+      plano: PlanoTipo.STARTER,
+      status: ClienteStatus.ATIVO,
+      maxUsuarios: 2,
+      dataProximaCobranca: addDays(now, 7),
+      criarUsuarios: 1, // + admin = 2
+    },
+    {
+      empresaId: "22222222-2222-2222-2222-222222222222",
+      empresaNome: "Cliente Seed Growth (5 users)",
+      cnpj: "22.222.222/0001-22",
+      emailComercial: "financeiro+growth@limvex.com.br",
+      plano: PlanoTipo.PROFESSIONAL,
+      status: ClienteStatus.ATIVO,
+      maxUsuarios: 5,
+      dataProximaCobranca: addDays(now, 14),
+      criarUsuarios: 4, // + admin = 5
+    },
+    {
+      empresaId: "33333333-3333-3333-3333-333333333333",
+      empresaNome: "Cliente Seed Suspenso",
+      cnpj: "33.333.333/0001-33",
+      emailComercial: "financeiro+suspenso@limvex.com.br",
+      plano: PlanoTipo.PROFESSIONAL,
+      status: ClienteStatus.SUSPENSO,
+      maxUsuarios: 5,
+      dataProximaCobranca: addDays(now, 3),
+      criarUsuarios: 2,
+    },
+    {
+      empresaId: "44444444-4444-4444-4444-444444444444",
+      empresaNome: "Cliente Seed Scale (downgrade bloqueado)",
+      cnpj: "44.444.444/0001-44",
+      emailComercial: "financeiro+scale@limvex.com.br",
+      plano: PlanoTipo.ENTERPRISE,
+      status: ClienteStatus.ATIVO,
+      maxUsuarios: 999999,
+      dataProximaCobranca: addDays(now, 30),
+      criarUsuarios: 6, // + admin = 7 (downgrade para STARTER deve falhar)
+    },
+  ] as const;
+
+  for (const c of clientes) {
+    const empresa = await upsertCliente(c);
+    console.log(`[seed pl03] OK: ${empresa.name} (${empresa.id})`);
+    console.log(`[seed pl03] login: admin+${c.empresaId}@limvex.com.br / senha: Admin@123`);
+  }
+}
+
+if (require.main === module) {
+  seedClientesPL03()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}
+

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, UserRole } from "@prisma/client";
 import * as bcrypt from "bcrypt";
+import { seedClientesPL03 } from "./seed-clientes-pl03";
 
 const prisma = new PrismaClient();
 const EMPRESA_ID = "00000000-0000-0000-0000-000000000001";
@@ -30,6 +31,8 @@ async function main() {
 
   console.log("Superadmin criado:", admin.email);
   console.log("Senha: Admin@123");
+
+  await seedClientesPL03();
 }
 
 main()

--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Body,
   Param,
   UseGuards,
@@ -13,6 +14,9 @@ import {
   ListarClientesDto,
   CriarContratoDto,
   RegistrarPagamentoDto,
+  PatchBillingPlanDto,
+  PatchBillingStatusDto,
+  PatchBillingExtendDto,
 } from "./dto";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { RolesGuard } from "../common/guards/roles.guard";
@@ -86,5 +90,45 @@ export class AdminController {
   @Roles(UserRole.SUPER_ADMIN)
   async listarPagamentos(@Param("contratoId") contratoId: string) {
     return this.adminService.listarPagamentos(contratoId);
+  }
+
+  // ========================================================
+  // Billing (PL-03)
+  // ========================================================
+
+  @Patch("billing/:companyId/plan")
+  @Roles(UserRole.SUPER_ADMIN)
+  async patchBillingPlan(
+    @Param("companyId") companyId: string,
+    @Body() dto: PatchBillingPlanDto,
+    @CurrentUser() user: { id: string; empresaId: string },
+  ) {
+    return this.adminService.patchBillingPlan(companyId, dto, user.id);
+  }
+
+  @Patch("billing/:companyId/status")
+  @Roles(UserRole.SUPER_ADMIN)
+  async patchBillingStatus(
+    @Param("companyId") companyId: string,
+    @Body() dto: PatchBillingStatusDto,
+    @CurrentUser() user: { id: string; empresaId: string },
+  ) {
+    return this.adminService.patchBillingStatus(companyId, dto, user.id);
+  }
+
+  @Patch("billing/:companyId/extend")
+  @Roles(UserRole.SUPER_ADMIN)
+  async patchBillingExtend(
+    @Param("companyId") companyId: string,
+    @Body() dto: PatchBillingExtendDto,
+    @CurrentUser() user: { id: string; empresaId: string },
+  ) {
+    return this.adminService.patchBillingExtend(companyId, dto, user.id);
+  }
+
+  @Get("billing/:companyId/audit")
+  @Roles(UserRole.SUPER_ADMIN)
+  async listarBillingAudit(@Param("companyId") companyId: string) {
+    return this.adminService.listarBillingAudit(companyId);
   }
 }

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -3,15 +3,20 @@ import {
   ConflictException,
   NotFoundException,
   Logger,
+  BadRequestException,
 } from "@nestjs/common";
 import { PrismaService } from "../prisma/prisma.service";
 import { MailService } from "../mail/mail.service";
 import { AuditLogService } from "../audit-log/audit-log.service";
+import { ClienteConfigCacheService } from "../common/services/cliente-config-cache.service";
 import {
   CriarClienteDto,
   ListarClientesDto,
   CriarContratoDto,
   RegistrarPagamentoDto,
+  PatchBillingPlanDto,
+  PatchBillingStatusDto,
+  PatchBillingExtendDto,
 } from "./dto";
 import { PlanoTipo, ClienteStatus, UserRole, TipoPagamento } from "@prisma/client";
 import * as bcrypt from "bcrypt";
@@ -25,7 +30,14 @@ export class AdminService {
     private readonly prisma: PrismaService,
     private readonly mailService: MailService,
     private readonly auditLogService: AuditLogService,
+    private readonly clienteConfigCache: ClienteConfigCacheService,
   ) {}
+
+  private limitesUsuariosPorPlano(plano: PlanoTipo): number {
+    if (plano === PlanoTipo.STARTER) return 2;
+    if (plano === PlanoTipo.PROFESSIONAL) return 5;
+    return 999999;
+  }
 
   /**
    * Cria um novo cliente B2B completo:
@@ -213,6 +225,157 @@ export class AdminService {
     });
 
     return clientes;
+  }
+
+  // ========================================================
+  // Billing (PL-03)
+  // ========================================================
+
+  async patchBillingPlan(companyId: string, dto: PatchBillingPlanDto, actorUserId: string) {
+    const novoPlano = dto.plano;
+    const novoMaxUsuarios = this.limitesUsuariosPorPlano(novoPlano);
+
+    return this.prisma.$transaction(async (tx) => {
+      const configAtual = await tx.clienteConfig.findUnique({
+        where: { empresaId: companyId },
+      });
+      if (!configAtual || configAtual.deletedAt) {
+        throw new NotFoundException("Configuração do cliente não encontrada");
+      }
+
+      const usuariosAtivos = await tx.user.count({
+        where: { empresaId: companyId, deletedAt: null },
+      });
+      if (usuariosAtivos > novoMaxUsuarios) {
+        throw new BadRequestException(
+          `Downgrade não permitido: a empresa possui ${usuariosAtivos} usuários ativos, mas o plano ${novoPlano} permite no máximo ${novoMaxUsuarios}. Remova usuários antes de reduzir o plano.`,
+        );
+      }
+
+      const atualizado = await tx.clienteConfig.update({
+        where: { empresaId: companyId },
+        data: {
+          plano: novoPlano,
+          maxUsuarios: novoMaxUsuarios,
+        },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          empresaId: companyId,
+          userId: actorUserId,
+          action: "billing.plan_changed",
+          resourceType: "Empresa",
+          resourceId: companyId,
+          metadata: {
+            planoAnterior: configAtual.plano,
+            planoNovo: novoPlano,
+            maxUsuariosAnterior: configAtual.maxUsuarios,
+            maxUsuariosNovo: novoMaxUsuarios,
+          } as any,
+        },
+      });
+
+      this.clienteConfigCache.invalidate(companyId);
+      return atualizado;
+    });
+  }
+
+  async patchBillingStatus(companyId: string, dto: PatchBillingStatusDto, actorUserId: string) {
+    const novoStatus = dto.status;
+
+    return this.prisma.$transaction(async (tx) => {
+      const configAtual = await tx.clienteConfig.findUnique({
+        where: { empresaId: companyId },
+      });
+      if (!configAtual || configAtual.deletedAt) {
+        throw new NotFoundException("Configuração do cliente não encontrada");
+      }
+
+      const atualizado = await tx.clienteConfig.update({
+        where: { empresaId: companyId },
+        data: { status: novoStatus },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          empresaId: companyId,
+          userId: actorUserId,
+          action: "billing.status_changed",
+          resourceType: "Empresa",
+          resourceId: companyId,
+          metadata: {
+            statusAnterior: configAtual.status,
+            statusNovo: novoStatus,
+          } as any,
+        },
+      });
+
+      this.clienteConfigCache.invalidate(companyId);
+      return atualizado;
+    });
+  }
+
+  async patchBillingExtend(companyId: string, dto: PatchBillingExtendDto, actorUserId: string) {
+    const novaData = new Date(dto.dataProximaCobranca);
+    if (Number.isNaN(novaData.getTime())) {
+      throw new BadRequestException("dataProximaCobranca inválida");
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const configAtual = await tx.clienteConfig.findUnique({
+        where: { empresaId: companyId },
+      });
+      if (!configAtual || configAtual.deletedAt) {
+        throw new NotFoundException("Configuração do cliente não encontrada");
+      }
+
+      const atualizado = await tx.clienteConfig.update({
+        where: { empresaId: companyId },
+        data: { dataProximaCobranca: novaData },
+      });
+
+      await tx.auditLog.create({
+        data: {
+          empresaId: companyId,
+          userId: actorUserId,
+          action: "billing.renewal_changed",
+          resourceType: "Empresa",
+          resourceId: companyId,
+          metadata: {
+            dataAnterior: configAtual.dataProximaCobranca,
+            dataNova: novaData,
+          } as any,
+        },
+      });
+
+      this.clienteConfigCache.invalidate(companyId);
+      return atualizado;
+    });
+  }
+
+  async listarBillingAudit(companyId: string) {
+    const logs = await this.prisma.auditLog.findMany({
+      where: {
+        empresaId: companyId,
+        action: { startsWith: "billing." },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    return logs.map((log) => ({
+      id: log.id,
+      action: log.action,
+      createdAt: log.createdAt.toISOString(),
+      user: log.user
+        ? { id: log.user.id, name: log.user.name, email: log.user.email }
+        : null,
+      metadata: log.metadata,
+    }));
   }
 
   /**

--- a/apps/api/src/admin/dto/index.ts
+++ b/apps/api/src/admin/dto/index.ts
@@ -2,3 +2,6 @@ export { CriarClienteDto } from "./criar-cliente.dto";
 export { ListarClientesDto } from "./listar-clientes.dto";
 export { CriarContratoDto } from "./criar-contrato.dto";
 export { RegistrarPagamentoDto } from "./registrar-pagamento.dto";
+export { PatchBillingPlanDto } from "./patch-billing-plan.dto";
+export { PatchBillingStatusDto } from "./patch-billing-status.dto";
+export { PatchBillingExtendDto } from "./patch-billing-extend.dto";

--- a/apps/api/src/admin/dto/patch-billing-extend.dto.ts
+++ b/apps/api/src/admin/dto/patch-billing-extend.dto.ts
@@ -1,0 +1,7 @@
+import { IsDateString } from "class-validator";
+
+export class PatchBillingExtendDto {
+  @IsDateString()
+  dataProximaCobranca!: string;
+}
+

--- a/apps/api/src/admin/dto/patch-billing-plan.dto.ts
+++ b/apps/api/src/admin/dto/patch-billing-plan.dto.ts
@@ -1,0 +1,8 @@
+import { IsEnum } from "class-validator";
+import { PlanoTipo } from "@prisma/client";
+
+export class PatchBillingPlanDto {
+  @IsEnum(PlanoTipo)
+  plano!: PlanoTipo;
+}
+

--- a/apps/api/src/admin/dto/patch-billing-status.dto.ts
+++ b/apps/api/src/admin/dto/patch-billing-status.dto.ts
@@ -1,0 +1,8 @@
+import { IsEnum } from "class-validator";
+import { ClienteStatus } from "@prisma/client";
+
+export class PatchBillingStatusDto {
+  @IsEnum(ClienteStatus)
+  status!: ClienteStatus;
+}
+

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -2,6 +2,7 @@ import { Global, Module } from "@nestjs/common";
 import { SoftDeleteService } from "./services/soft-delete.service";
 import { AuditLogModule } from "../audit-log/audit-log.module";
 import { FeatureAccessGuard } from "./guards/feature-access.guard";
+import { ClienteConfigCacheService } from "./services/cliente-config-cache.service";
 
 /**
  * Módulo comum para serviços compartilhados
@@ -11,7 +12,7 @@ import { FeatureAccessGuard } from "./guards/feature-access.guard";
 @Global()
 @Module({
   imports: [AuditLogModule], // SoftDeleteService depende do AuditLogService
-  providers: [SoftDeleteService, FeatureAccessGuard],
-  exports: [SoftDeleteService, FeatureAccessGuard],
+  providers: [SoftDeleteService, ClienteConfigCacheService, FeatureAccessGuard],
+  exports: [SoftDeleteService, ClienteConfigCacheService, FeatureAccessGuard],
 })
 export class CommonModule {}

--- a/apps/api/src/common/guards/feature-access.guard.ts
+++ b/apps/api/src/common/guards/feature-access.guard.ts
@@ -6,8 +6,7 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
-import { ClienteStatus, PlanoTipo } from "@prisma/client";
-import { PrismaService } from "../../prisma/prisma.service";
+import { ClienteStatus } from "@prisma/client";
 import { IS_PUBLIC_KEY } from "../../auth/decorators/public.decorator";
 import { FEATURE_KEY } from "../decorators/require-feature.decorator";
 import {
@@ -15,21 +14,13 @@ import {
   type FeatureName,
   getRequiredPlan,
 } from "../constants/feature-matrix";
-
-interface CachedCliente {
-  plano: PlanoTipo;
-  status: ClienteStatus;
-  fetchedAt: number;
-}
-
-const clienteConfigCache = new Map<string, CachedCliente>();
-const TTL_MS = 60_000;
+import { ClienteConfigCacheService } from "../services/cliente-config-cache.service";
 
 @Injectable()
 export class FeatureAccessGuard implements CanActivate {
   constructor(
     private readonly reflector: Reflector,
-    private readonly prisma: PrismaService,
+    private readonly clienteConfigCache: ClienteConfigCacheService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -56,7 +47,7 @@ export class FeatureAccessGuard implements CanActivate {
     }
 
     const empresaId = user.empresaId;
-    const { plano, status } = await this.getClientePlanAndStatus(empresaId);
+    const { plano, status } = await this.clienteConfigCache.getPlanAndStatus(empresaId);
 
     if (status === ClienteStatus.SUSPENSO || status === ClienteStatus.CANCELADO) {
       throw new ForbiddenException({
@@ -80,26 +71,5 @@ export class FeatureAccessGuard implements CanActivate {
     }
 
     return true;
-  }
-
-  private async getClientePlanAndStatus(
-    empresaId: string,
-  ): Promise<{ plano: PlanoTipo; status: ClienteStatus }> {
-    const now = Date.now();
-    const cached = clienteConfigCache.get(empresaId);
-    if (cached && now - cached.fetchedAt <= TTL_MS) {
-      return { plano: cached.plano, status: cached.status };
-    }
-
-    const config = await this.prisma.clienteConfig.findFirst({
-      where: { empresaId, deletedAt: null },
-    });
-
-    const plano = config?.plano ?? PlanoTipo.STARTER;
-    const status = config?.status ?? ClienteStatus.ATIVO;
-
-    clienteConfigCache.set(empresaId, { plano, status, fetchedAt: now });
-
-    return { plano, status };
   }
 }

--- a/apps/api/src/common/services/cliente-config-cache.service.ts
+++ b/apps/api/src/common/services/cliente-config-cache.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from "@nestjs/common";
+import { ClienteStatus, PlanoTipo } from "@prisma/client";
+import { PrismaService } from "../../prisma/prisma.service";
+
+interface CachedCliente {
+  plano: PlanoTipo;
+  status: ClienteStatus;
+  fetchedAt: number;
+}
+
+const TTL_MS = 60_000;
+
+@Injectable()
+export class ClienteConfigCacheService {
+  private readonly cache = new Map<string, CachedCliente>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  invalidate(empresaId: string) {
+    this.cache.delete(empresaId);
+  }
+
+  async getPlanAndStatus(empresaId: string): Promise<{ plano: PlanoTipo; status: ClienteStatus }> {
+    const now = Date.now();
+    const cached = this.cache.get(empresaId);
+    if (cached && now - cached.fetchedAt <= TTL_MS) {
+      return { plano: cached.plano, status: cached.status };
+    }
+
+    const config = await this.prisma.clienteConfig.findFirst({
+      where: { empresaId, deletedAt: null },
+      select: { plano: true, status: true },
+    });
+
+    const plano = config?.plano ?? PlanoTipo.STARTER;
+    const status = config?.status ?? ClienteStatus.ATIVO;
+
+    this.cache.set(empresaId, { plano, status, fetchedAt: now });
+    return { plano, status };
+  }
+}
+

--- a/apps/web/src/app/admin/clientes/page.tsx
+++ b/apps/web/src/app/admin/clientes/page.tsx
@@ -19,14 +19,16 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/Badge";
-import { Plus, Search, Download, Users, DollarSign, TrendingDown } from "lucide-react";
+import { Plus, Search, Download, Users, DollarSign, TrendingDown, Infinity as InfinityIcon } from "lucide-react";
 import { CriarClienteModal } from "@/components/admin/criar-cliente-modal";
+import { BillingEditModal } from "@/components/admin/BillingEditModal";
 import { api } from "@/lib/api";
 import { formatCurrency, formatCNPJ, formatDate } from "@/lib/utils";
 import { Layout } from "@/components/layout";
 import { useAuth } from "@/contexts/auth-context";
 import { toast } from "@/hooks/use-toast";
 import { AuthGuard } from "@/components/AuthGuard";
+import { PLAN_DISPLAY_NAMES } from "@/constants/plans";
 
 interface ClienteConfig {
   id: string;
@@ -35,6 +37,8 @@ interface ClienteConfig {
   email: string;
   plano: "STARTER" | "PROFESSIONAL" | "ENTERPRISE";
   status: "ATIVO" | "SUSPENSO" | "CANCELADO" | "TRIAL";
+  maxUsuarios: number;
+  dataProximaCobranca?: string | null;
   mensalidade: number;
   valorSetup: number;
   dataInicio: string;
@@ -74,6 +78,8 @@ export default function PainelAdminClientes() {
   const [loading, setLoading] = useState(true);
   const [busca, setBusca] = useState("");
   const [modalAberto, setModalAberto] = useState(false);
+  const [billingModalOpen, setBillingModalOpen] = useState(false);
+  const [billingTarget, setBillingTarget] = useState<ClienteConfig | null>(null);
 
   // Proteção de rota: apenas SUPER_ADMIN pode acessar
   useEffect(() => {
@@ -112,6 +118,11 @@ export default function PainelAdminClientes() {
       setLoading(false);
     }
   }, [router]);
+
+  const abrirBilling = (cliente: ClienteConfig) => {
+    setBillingTarget(cliente);
+    setBillingModalOpen(true);
+  };
 
   useEffect(() => {
     // Só carregar dados se for SUPER_ADMIN
@@ -167,6 +178,18 @@ export default function PainelAdminClientes() {
       ENTERPRISE: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800",
     };
     return variants[plano] || "bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-300";
+  };
+
+  const renderMaxUsuarios = (maxUsuarios: number) => {
+    if (maxUsuarios >= 999999) {
+      return (
+        <span className="inline-flex items-center gap-1 justify-center leading-none">
+          <InfinityIcon className="h-4 w-4 relative top-[2px]" />
+          <span className="sr-only">Ilimitado</span>
+        </span>
+      );
+    }
+    return String(maxUsuarios);
   };
 
   // Enquanto verifica auth ou se não é SUPER_ADMIN
@@ -296,15 +319,17 @@ export default function PainelAdminClientes() {
                       <TableHead>Plano</TableHead>
                       <TableHead className="text-center">Usuários</TableHead>
                       <TableHead className="text-center">Licitações</TableHead>
+                      <TableHead>Vencimento</TableHead>
                       <TableHead>Mensalidade</TableHead>
                       <TableHead>Status</TableHead>
                       <TableHead>Início</TableHead>
+                      <TableHead className="text-right">Ações</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {clientesFiltrados.length === 0 ? (
                       <TableRow>
-                        <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
+                        <TableCell colSpan={10} className="text-center text-muted-foreground py-8">
                           {busca
                             ? "Nenhum cliente encontrado para essa busca"
                             : "Nenhum cliente cadastrado. Clique em \"Novo Cliente\" para começar."}
@@ -321,11 +346,17 @@ export default function PainelAdminClientes() {
                           <TableCell className="font-mono text-sm">{formatCNPJ(cliente.cnpj)}</TableCell>
                           <TableCell>
                             <Badge variant="outline" className={badgePlanoVariant(cliente.plano)}>
-                              {cliente.plano}
+                              {PLAN_DISPLAY_NAMES[cliente.plano] ?? cliente.plano}
                             </Badge>
                           </TableCell>
-                          <TableCell className="text-center">{cliente.empresa._count.users}</TableCell>
+                          <TableCell className="text-center">
+                            {cliente.empresa._count.users}/
+                            {cliente.maxUsuarios != null ? renderMaxUsuarios(cliente.maxUsuarios) : "-"}
+                          </TableCell>
                           <TableCell className="text-center">{cliente.empresa._count.bids}</TableCell>
+                          <TableCell className="text-sm">
+                            {cliente.dataProximaCobranca ? formatDate(cliente.dataProximaCobranca) : "-"}
+                          </TableCell>
                           <TableCell>{formatCurrency(Number(cliente.mensalidade))}</TableCell>
                           <TableCell>
                             <Badge variant="outline" className={badgeStatusVariant(cliente.status)}>
@@ -333,6 +364,19 @@ export default function PainelAdminClientes() {
                             </Badge>
                           </TableCell>
                           <TableCell className="text-sm">{formatDate(cliente.dataInicio)}</TableCell>
+                          <TableCell className="text-right">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                abrirBilling(cliente);
+                              }}
+                            >
+                              Billing
+                            </Button>
+                          </TableCell>
                         </TableRow>
                       ))
                     )}
@@ -351,6 +395,25 @@ export default function PainelAdminClientes() {
               carregarDados();
             }}
           />
+
+          {billingTarget && (
+            <BillingEditModal
+              open={billingModalOpen}
+              onOpenChange={(o) => {
+                setBillingModalOpen(o);
+                if (!o) setBillingTarget(null);
+              }}
+              companyId={billingTarget.empresaId}
+              companyName={billingTarget.empresa.name}
+              cnpj={billingTarget.cnpj}
+              planoAtual={billingTarget.plano}
+              statusAtual={billingTarget.status}
+              maxUsuariosAtual={billingTarget.maxUsuarios ?? 0}
+              usuariosAtivos={billingTarget.empresa._count.users}
+              dataProximaCobrancaAtual={billingTarget.dataProximaCobranca ?? null}
+              onSaved={() => carregarDados()}
+            />
+          )}
         </div>
       </Layout>
     </AuthGuard >

--- a/apps/web/src/components/admin/BillingEditModal.tsx
+++ b/apps/web/src/components/admin/BillingEditModal.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "@/hooks/use-toast";
+import {
+  adminGetCompanyBillingAudit,
+  adminUpdateCompanyPlan,
+  adminUpdateCompanyRenewalDate,
+  adminUpdateCompanyStatus,
+  type AdminClienteStatus,
+  type AdminPlanoTipo,
+} from "@/lib/api";
+import { PLAN_DISPLAY_NAMES } from "@/constants/plans";
+import { Infinity as InfinityIcon } from "lucide-react";
+import { formatCNPJ } from "@/lib/utils";
+
+interface BillingEditModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  companyName: string;
+  cnpj: string;
+  planoAtual: AdminPlanoTipo;
+  statusAtual: AdminClienteStatus;
+  maxUsuariosAtual: number;
+  usuariosAtivos: number;
+  dataProximaCobrancaAtual?: string | null;
+  onSaved?: () => void;
+}
+
+function toDateInputValue(isoOrNull?: string | null) {
+  if (!isoOrNull) return "";
+  const d = new Date(isoOrNull);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString().split("T")[0];
+}
+
+function displayPlan(plano: string) {
+  return PLAN_DISPLAY_NAMES[plano] ?? plano;
+}
+
+function displayAuditAction(action: string) {
+  if (action === "billing.plan_changed") return "Plano alterado";
+  if (action === "billing.status_changed") return "Status alterado";
+  if (action === "billing.renewal_changed") return "Vencimento alterado";
+  return action;
+}
+
+function renderMaxUsuarios(max: number) {
+  if (max >= 999999) {
+    return (
+      <span className="inline-flex items-center justify-center gap-1 leading-none">
+        <InfinityIcon className="h-4 w-4 relative top-[3px]" />
+        <span className="sr-only">Ilimitado</span>
+      </span>
+    );
+  }
+  return <span>{max}</span>;
+}
+
+export function BillingEditModal({
+  open,
+  onOpenChange,
+  companyId,
+  companyName,
+  cnpj,
+  planoAtual,
+  statusAtual,
+  maxUsuariosAtual,
+  usuariosAtivos,
+  dataProximaCobrancaAtual,
+  onSaved,
+}: BillingEditModalProps) {
+  const [saving, setSaving] = useState(false);
+  const [plano, setPlano] = useState<AdminPlanoTipo>(planoAtual);
+  const [status, setStatus] = useState<AdminClienteStatus>(statusAtual);
+  const [vencimento, setVencimento] = useState<string>(toDateInputValue(dataProximaCobrancaAtual));
+  const [audit, setAudit] = useState<Array<{ id: string; action: string; createdAt: string; user: { name: string; email: string } | null; metadata: unknown }>>([]);
+  const [loadingAudit, setLoadingAudit] = useState(false);
+
+  const mudou = useMemo(() => {
+    return (
+      plano !== planoAtual ||
+      status !== statusAtual ||
+      vencimento !== toDateInputValue(dataProximaCobrancaAtual)
+    );
+  }, [plano, planoAtual, status, statusAtual, vencimento, dataProximaCobrancaAtual]);
+
+  useEffect(() => {
+    if (!open) return;
+    setPlano(planoAtual);
+    setStatus(statusAtual);
+    setVencimento(toDateInputValue(dataProximaCobrancaAtual));
+  }, [open, planoAtual, statusAtual, dataProximaCobrancaAtual]);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoadingAudit(true);
+    adminGetCompanyBillingAudit(companyId)
+      .then((logs) => {
+        setAudit(
+          (logs ?? []).map((l) => ({
+            id: l.id,
+            action: l.action,
+            createdAt: l.createdAt,
+            user: l.user ? { name: l.user.name, email: l.user.email } : null,
+            metadata: l.metadata,
+          })),
+        );
+      })
+      .catch(() => setAudit([]))
+      .finally(() => setLoadingAudit(false));
+  }, [open, companyId]);
+
+  async function salvar() {
+    if (!mudou) {
+      onOpenChange(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      if (plano !== planoAtual) {
+        await adminUpdateCompanyPlan(companyId, plano);
+      }
+      if (status !== statusAtual) {
+        await adminUpdateCompanyStatus(companyId, status);
+      }
+      const vencimentoAtualStr = toDateInputValue(dataProximaCobrancaAtual);
+      if (vencimento !== vencimentoAtualStr) {
+        if (!vencimento) {
+          toast({
+            title: "Data inválida",
+            description: "Informe uma data de vencimento válida.",
+            variant: "destructive",
+          });
+          return;
+        }
+        // enviar como ISO completo para o backend
+        const iso = new Date(`${vencimento}T00:00:00.000Z`).toISOString();
+        await adminUpdateCompanyRenewalDate(companyId, iso);
+      }
+
+      toast({ title: "Billing atualizado", description: "As alterações foram aplicadas com sucesso." });
+      onSaved?.();
+      onOpenChange(false);
+    } catch (e: any) {
+      const msg =
+        e?.response?.data?.message ||
+        e?.message ||
+        "Não foi possível salvar as alterações de billing.";
+      toast({ title: "Erro", description: String(msg), variant: "destructive" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const planoOptions: Array<{ value: AdminPlanoTipo; label: string }> = [
+    { value: "STARTER", label: displayPlan("STARTER") },
+    { value: "PROFESSIONAL", label: displayPlan("PROFESSIONAL") },
+    { value: "ENTERPRISE", label: displayPlan("ENTERPRISE") },
+  ];
+
+  const statusOptions: Array<{ value: AdminClienteStatus; label: string }> = [
+    { value: "ATIVO", label: "ATIVO" },
+    { value: "TRIAL", label: "TRIAL" },
+    { value: "SUSPENSO", label: "SUSPENSO" },
+    { value: "CANCELADO", label: "CANCELADO" },
+  ];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Editar Billing</DialogTitle>
+          <DialogDescription>
+            {companyName} • {formatCNPJ(cnpj)}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>Plano</Label>
+            <Select value={plano} onValueChange={(v) => setPlano(v as AdminPlanoTipo)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione o plano" />
+              </SelectTrigger>
+              <SelectContent>
+                {planoOptions.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Usuários: {usuariosAtivos}/{renderMaxUsuarios(maxUsuariosAtual)}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Status</Label>
+            <Select value={status} onValueChange={(v) => setStatus(v as AdminClienteStatus)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione o status" />
+              </SelectTrigger>
+              <SelectContent>
+                {statusOptions.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>
+                    {s.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2 md:col-span-2">
+            <Label>Data de vencimento</Label>
+            <Input
+              type="date"
+              value={vencimento}
+              onChange={(e) => setVencimento(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Controla o vencimento (próxima cobrança) da empresa.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 border-t pt-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold">Últimas mudanças</h3>
+          </div>
+          {loadingAudit ? (
+            <p className="text-sm text-muted-foreground mt-2">Carregando histórico...</p>
+          ) : audit.length === 0 ? (
+            <p className="text-sm text-muted-foreground mt-2">Sem alterações recentes de billing.</p>
+          ) : (
+            <div className="mt-2 space-y-2 text-sm">
+              {audit.map((l) => (
+                <div key={l.id} className="rounded-md border border-border p-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-xs text-muted-foreground">{displayAuditAction(l.action)}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(l.createdAt).toLocaleString("pt-BR")}
+                    </span>
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1">
+                    {l.user ? `${l.user.name} (${l.user.email})` : "Sistema"}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancelar
+          </Button>
+          <Button onClick={salvar} disabled={saving || !mudou}>
+            {saving ? "Salvando..." : "Salvar"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -258,6 +258,44 @@ export async function buscarLicitacoes(): Promise<LicitacaoResumo[]> {
   return data?.data ?? [];
 }
 
+// ========================================================
+// Admin / Billing (PL-03)
+// ========================================================
+
+export type AdminPlanoTipo = "STARTER" | "PROFESSIONAL" | "ENTERPRISE";
+export type AdminClienteStatus = "ATIVO" | "SUSPENSO" | "CANCELADO" | "TRIAL";
+
+export async function adminUpdateCompanyPlan(companyId: string, plano: AdminPlanoTipo) {
+  const { data } = await api.patch(`/admin/billing/${companyId}/plan`, { plano });
+  return data;
+}
+
+export async function adminUpdateCompanyStatus(companyId: string, status: AdminClienteStatus) {
+  const { data } = await api.patch(`/admin/billing/${companyId}/status`, { status });
+  return data;
+}
+
+export async function adminUpdateCompanyRenewalDate(
+  companyId: string,
+  dataProximaCobranca: string,
+) {
+  const { data } = await api.patch(`/admin/billing/${companyId}/extend`, { dataProximaCobranca });
+  return data;
+}
+
+export async function adminGetCompanyBillingAudit(companyId: string): Promise<
+  Array<{
+    id: string;
+    action: string;
+    createdAt: string;
+    user: { id: string; name: string; email: string } | null;
+    metadata: unknown;
+  }>
+> {
+  const { data } = await api.get(`/admin/billing/${companyId}/audit`);
+  return data;
+}
+
 export async function listarDisputas(params?: {
   status?: DisputaStatus;
   bidId?: string;


### PR DESCRIPTION
Adiciona endpoints admin para SUPER_ADMIN alterar plano, status e vencimento (ClienteConfig), com validação de downgrade por limite de usuários e registro de auditoria (billing.*) em transação.

Inclui invalidação de cache do FeatureAccessGuard para refletir permissões imediatamente sem logout. No web, adiciona modal de edição de billing (plano/status/vencimento + últimas mudanças) e integra na tabela de /admin/clientes com colunas de usuários (atual/máx) e vencimento.